### PR TITLE
fix(build): skip i18n:release errors to prevent build failure

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -125,7 +125,7 @@ log_info "Archive name will be: ${archive_name}.tar.gz"
 log_step "==== Installing dependencies ===="
 pnpm install
 log_step "==== Building i18n ===="
-pnpm i18n:release
+pnpm i18n:release || log_warning "i18n build failed, continuing..."
 log_step "==== Building project ===="
 pnpm build
 


### PR DESCRIPTION
Crowdin requires a key to download translations. In some environments where no key is specified, which causes the build to fail.