### PR TITLE
ci: bundle i18n assets in release

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -141,7 +141,7 @@ jobs:
             --notes-file "${{ github.workspace }}-CHANGELOG.txt" \
             --prerelease=${{ steps.check_pre_release.outputs.is_pre_release }} \
             ${{ steps.get_current_tag.outputs.current_tag }} \
-            dist/openlist-frontend-dist-v*.tar.gz
+            dist/openlist-frontend-dist-v*.tar.gz dist/i18n.tar.gz
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Crowdin lang files require an access token to download, which complicates source builds and packaging.
This PR adds the prebuilt `i18n.tar.gz` to release artifacts to enable full functionality when building from source.

---

由于从 Crowdin 下载翻译文件需要token，这对从源码构建的用户以及发行版打包来说并不方便
因此将预构建的 `i18n.tar.gz` 包含进发布里，以便下游在构建源码时能够获取它并解压到src/lang下获得完整的i18n支持
