### PR TITLE
feat: Add text previews to small files without matched preview (<1MB)

### DIFF
--- a/src/pages/home/previews/index.ts
+++ b/src/pages/home/previews/index.ts
@@ -190,22 +190,30 @@ export const getPreviews = (
   )
 
   // ==================== NEW LOGIC START ====================
-  // Step 2: Check conditions for the special case.
+  // This block handles the positioning of the "Download" option and other special cases.
+
+  // Define the Download component once to avoid repetition.
+  const downloadComponent: PreviewComponent = {
+    name: "Download",
+    component: lazy(() => import("./download")),
+  }
+
+  // Condition for the new requirement: a large text file.
+  const isLargeTextFile =
+    file.type === ObjType.TEXT && file.size >= 1 * 1024 * 1024
+
+  // Conditions from the previous logic for small, unrecognized files.
   const noPreviewsFound = res.length === 0 && subsequent.length === 0
   const isSmallFile = file.size < 1 * 1024 * 1024
 
-  // Step 3: Handle the "Download" option and special case previews.
-  if (noPreviewsFound && isSmallFile) {
-    // This is the special case: no previews found for a small file.
-    // The list "res" is currently empty.
-
-    // 1. Add "Download" as the very first option.
-    res.push({
-      name: "Download",
-      component: lazy(() => import("./download")),
-    })
-
-    // 2. Then, add the default text previews after "Download".
+  if (isLargeTextFile) {
+    // Case 1 (New): Large text file. Place "Download" at the very beginning.
+    // The standard text previews (Markdown, etc.) are already in `res` and will appear after it.
+    res.unshift(downloadComponent)
+  } else if (noPreviewsFound && isSmallFile) {
+    // Case 2 (Original): No other previews found for a small file.
+    // Add "Download" first, then suggest default text previews.
+    res.push(downloadComponent)
     const textPreviewsToAdd = previews
       .filter((p) =>
         ["Markdown", "Markdown with word wrap", "Text Editor"].includes(p.name),
@@ -213,13 +221,9 @@ export const getPreviews = (
       .map((p) => ({ name: p.name, component: p.component }))
     res.push(...textPreviewsToAdd)
   } else {
-    // This is the normal case for all other files.
-    // "res" may contain previews for videos, documents, etc.
+    // Case 3 (Original): The "normal" case for all other files (images, videos, small text files, etc.).
     // Add "Download" as the last fallback option in the high-priority list.
-    res.push({
-      name: "Download",
-      component: lazy(() => import("./download")),
-    })
+    res.push(downloadComponent)
   }
   // ==================== NEW LOGIC END ====================
 

--- a/src/pages/home/previews/index.ts
+++ b/src/pages/home/previews/index.ts
@@ -40,7 +40,6 @@ export interface Preview {
 export type PreviewComponent = Pick<Preview, "name" | "component">
 
 const previews: Preview[] = [
-  // ... (The array of preview definitions remains unchanged)
   {
     name: "HTML render",
     exts: ["html"],
@@ -162,8 +161,7 @@ export const getPreviews = (
     ObjType[searchParams["type"]?.toUpperCase() as keyof typeof ObjType]
   const res: PreviewComponent[] = []
   const subsequent: PreviewComponent[] = []
-
-  // Step 1: Run the original logic to find all matching previews.
+  // internal previews
   previews.forEach((preview) => {
     if (preview.provider && !preview.provider.test(file.provider)) {
       return
@@ -181,6 +179,7 @@ export const getPreviews = (
       }
     }
   })
+  // iframe previews
   const iframePreviews = getIframePreviews(file.name)
   res.push(
     ...iframePreviews.map((preview) => ({
@@ -189,10 +188,7 @@ export const getPreviews = (
     })),
   )
 
-  // ==================== NEW LOGIC START ====================
-  // This block handles the positioning of the "Download" option and other special cases.
-
-  // Define the Download component once to avoid repetition.
+  // download page
   const downloadComponent: PreviewComponent = {
     name: "Download",
     component: lazy(() => import("./download")),
@@ -207,11 +203,11 @@ export const getPreviews = (
   const isSmallFile = file.size < 1 * 1024 * 1024
 
   if (isLargeTextFile) {
-    // Case 1 (New): Large text file. Place "Download" at the very beginning.
+    // Case 1: Large text file. Place "Download" at the very beginning.
     // The standard text previews (Markdown, etc.) are already in `res` and will appear after it.
     res.unshift(downloadComponent)
   } else if (noPreviewsFound && isSmallFile) {
-    // Case 2 (Original): No other previews found for a small file.
+    // Case 2: No other previews found for a small file.
     // Add "Download" first, then suggest default text previews.
     res.push(downloadComponent)
     const textPreviewsToAdd = previews
@@ -221,12 +217,9 @@ export const getPreviews = (
       .map((p) => ({ name: p.name, component: p.component }))
     res.push(...textPreviewsToAdd)
   } else {
-    // Case 3 (Original): The "normal" case for all other files (images, videos, small text files, etc.).
+    // Case 3: The "normal" case for all other files (images, videos, small text files, etc.).
     // Add "Download" as the last fallback option in the high-priority list.
     res.push(downloadComponent)
   }
-  // ==================== NEW LOGIC END ====================
-
-  // Step 4: Return the combined list.
   return res.concat(subsequent)
 }

--- a/src/pages/home/previews/index.ts
+++ b/src/pages/home/previews/index.ts
@@ -40,6 +40,7 @@ export interface Preview {
 export type PreviewComponent = Pick<Preview, "name" | "component">
 
 const previews: Preview[] = [
+  // ... (The array of preview definitions remains unchanged)
   {
     name: "HTML render",
     exts: ["html"],
@@ -161,7 +162,8 @@ export const getPreviews = (
     ObjType[searchParams["type"]?.toUpperCase() as keyof typeof ObjType]
   const res: PreviewComponent[] = []
   const subsequent: PreviewComponent[] = []
-  // internal previews
+
+  // Step 1: Run the original logic to find all matching previews.
   previews.forEach((preview) => {
     if (preview.provider && !preview.provider.test(file.provider)) {
       return
@@ -179,18 +181,48 @@ export const getPreviews = (
       }
     }
   })
-  // iframe previews
   const iframePreviews = getIframePreviews(file.name)
-  iframePreviews.forEach((preview) => {
-    res.push({
+  res.push(
+    ...iframePreviews.map((preview) => ({
       name: preview.key,
       component: generateIframePreview(preview.value),
+    })),
+  )
+
+  // ==================== NEW LOGIC START ====================
+  // Step 2: Check conditions for the special case.
+  const noPreviewsFound = res.length === 0 && subsequent.length === 0
+  const isSmallFile = file.size < 1 * 1024 * 1024
+
+  // Step 3: Handle the "Download" option and special case previews.
+  if (noPreviewsFound && isSmallFile) {
+    // This is the special case: no previews found for a small file.
+    // The list "res" is currently empty.
+
+    // 1. Add "Download" as the very first option.
+    res.push({
+      name: "Download",
+      component: lazy(() => import("./download")),
     })
-  })
-  // download page
-  res.push({
-    name: "Download",
-    component: lazy(() => import("./download")),
-  })
+
+    // 2. Then, add the default text previews after "Download".
+    const textPreviewsToAdd = previews
+      .filter((p) =>
+        ["Markdown", "Markdown with word wrap", "Text Editor"].includes(p.name),
+      )
+      .map((p) => ({ name: p.name, component: p.component }))
+    res.push(...textPreviewsToAdd)
+  } else {
+    // This is the normal case for all other files.
+    // "res" may contain previews for videos, documents, etc.
+    // Add "Download" as the last fallback option in the high-priority list.
+    res.push({
+      name: "Download",
+      component: lazy(() => import("./download")),
+    })
+  }
+  // ==================== NEW LOGIC END ====================
+
+  // Step 4: Return the combined list.
   return res.concat(subsequent)
 }


### PR DESCRIPTION
Add text preview options for small files that don't match any existing preview types, making it easier to view text files without file extensions.

![图片](https://github.com/user-attachments/assets/7b3f8f78-96f3-4e72-8286-6cd067ac22a8)

