### PR TITLE
fix(i18n): add missing translations

### DIFF
--- a/src/hooks/useT.ts
+++ b/src/hooks/useT.ts
@@ -1,24 +1,33 @@
 import { dict, i18n, languages } from "~/app/i18n"
 import { firstUpperCase } from "~/utils"
 
-export const useT = () => {
-  const t = i18n.translator(dict)
-  const tt = (key: string, params?: i18n.BaseTemplateArgs) => {
-    return i18n.resolveTemplate ? i18n.resolveTemplate(key, params) : t(key)
+const translator = i18n.translator(dict)
+
+const resolveTranslation = (
+  key: string,
+  params?: i18n.BaseTemplateArgs,
+): string | undefined => {
+  const template = translator(key)
+  if (typeof template !== "string") {
+    return undefined
   }
+
+  if (params) {
+    return i18n.resolveTemplate(template, params) || template
+  }
+
+  return template
+}
+export const useT = () => {
   return (
     key: string,
     params?: i18n.BaseTemplateArgs | undefined,
     defaultValue?: string | undefined,
-  ) => {
-    const value = params
-      ? (tt(key, params) as string | undefined)
-      : (t(key) as string | undefined)
+  ): string => {
+    const translatedValue = resolveTranslation(key, params)
 
-    if (value) return value
-
+    if (translatedValue) return translatedValue
     if (defaultValue) return defaultValue
-
     if (import.meta.env.DEV) return key
 
     return formatKeyAsDisplay(key)

--- a/src/lang/en/home.json
+++ b/src/lang/en/home.json
@@ -162,6 +162,7 @@
       "sticky": "Stick to top of page",
       "only_navbar_sticky": "Only nav bar sticky"
     },
+    "grid_item_size": "Grid item size",
     "show_sidebar": "Show sidebar",
     "show_sidebar_options": {
       "none": "None",

--- a/src/lang/en/settings.json
+++ b/src/lang/en/settings.json
@@ -49,6 +49,8 @@
   "ldap_user_search_base": "Ldap user search base",
   "ldap_user_search_filter": "Ldap user search filter",
   "link_expiration": "Link expiration",
+  "load_default_setting": "Load default settings",
+  "load_default_setting_success": "Load default settings successfully",
   "logo": "Logo",
   "main_color": "Main color",
   "max_client_download_speed": "Max client download speed",

--- a/src/lang/en/storages.json
+++ b/src/lang/en/storages.json
@@ -10,6 +10,8 @@
     "cache_expiration": "Cache Expiration",
     "cache_expiration-tips": "The cache expiration time for this storage(minutes)",
     "down_proxy_url": "Download proxy URL",
+    "disable_proxy_sign": "Disable proxy sign",
+    "disable_proxy_sign-tips": "Disable sign for Download proxy URL",
     "web_proxy": "Web proxy",
     "webdav_policy": "WebDAV policy",
     "proxy_range": "Proxy Range",


### PR DESCRIPTION
These translations cannot be added by running `./openlist lang`. So add them manually.

Refactor the usage of `@solid-primitives/i18n`.

Fixes:

![](https://github.com/user-attachments/assets/a9da2194-71ae-442c-b27d-60318fe0c164)

![](https://github.com/user-attachments/assets/c9c868c2-e5e7-4864-84e9-4b948fbdd638)

![](https://github.com/user-attachments/assets/7b194986-7bd9-494f-9044-e4789e6dd1e1)

![](https://github.com/user-attachments/assets/3d231caf-689a-491d-8410-85d416f9c213)
