### PR TITLE
feat(folder): move the count msg to bottom and add options

### DIFF
--- a/src/lang/en/home.json
+++ b/src/lang/en/home.json
@@ -168,6 +168,11 @@
       "none": "None",
       "visible": "Visible"
     },
+    "show_count_msg": "Show file count message",
+    "show_count_msg_options": {
+      "none": "None",
+      "visible": "Visible"
+    },
     "list_item_filename_overflow": "List item filename overflow",
     "list_item_filename_overflow_options": {
       "ellipsis": "Ellipsis",

--- a/src/pages/home/folder/Grid.tsx
+++ b/src/pages/home/folder/Grid.tsx
@@ -1,5 +1,5 @@
 import { Box, Grid, Text } from "@hope-ui/solid"
-import { For } from "solid-js"
+import { For, Show } from "solid-js"
 import { GridItem } from "./GridItem"
 import "lightgallery/css/lightgallery-bundle.css"
 import { countMsg, local, objStore } from "~/store"
@@ -11,9 +11,6 @@ const GridLayout = () => {
   registerSelectContainer()
   return (
     <>
-      <Box w="100%" textAlign="left" pl="$2">
-        <Text>{countMsg()}</Text>
-      </Box>
       <Grid
         oncapture:contextmenu={captureContentMenu}
         class="viselect-container"
@@ -29,6 +26,11 @@ const GridLayout = () => {
           }}
         </For>
       </Grid>
+      <Show when={local["show_count_msg"] === "visible"}>
+        <Text size="sm" color="$neutral11">
+          {countMsg()}
+        </Text>
+      </Show>
     </>
   )
 }

--- a/src/pages/home/folder/Grid.tsx
+++ b/src/pages/home/folder/Grid.tsx
@@ -13,7 +13,9 @@ const GridLayout = () => {
     <>
       <Show when={local["show_count_msg"] === "visible"}>
         <Box w="100%" textAlign="left" pl="$2">
-          <Text>{smartCountMsg()}</Text>
+          <Text size="sm" color="$neutral11">
+            {smartCountMsg()}
+          </Text>
         </Box>
       </Show>
       <Grid

--- a/src/pages/home/folder/Grid.tsx
+++ b/src/pages/home/folder/Grid.tsx
@@ -2,7 +2,7 @@ import { Box, Grid, Text } from "@hope-ui/solid"
 import { For, Show } from "solid-js"
 import { GridItem } from "./GridItem"
 import "lightgallery/css/lightgallery-bundle.css"
-import { countMsg, local, objStore } from "~/store"
+import { smartCountMsg, local, objStore } from "~/store"
 import { useSelectWithMouse } from "./helper"
 
 const GridLayout = () => {
@@ -11,6 +11,11 @@ const GridLayout = () => {
   registerSelectContainer()
   return (
     <>
+      <Show when={local["show_count_msg"] === "visible"}>
+        <Box w="100%" textAlign="left" pl="$2">
+          <Text>{smartCountMsg()}</Text>
+        </Box>
+      </Show>
       <Grid
         oncapture:contextmenu={captureContentMenu}
         class="viselect-container"
@@ -26,11 +31,6 @@ const GridLayout = () => {
           }}
         </For>
       </Grid>
-      <Show when={local["show_count_msg"] === "visible"}>
-        <Text size="sm" color="$neutral11">
-          {countMsg()}
-        </Text>
-      </Show>
     </>
   )
 }

--- a/src/pages/home/folder/Images.tsx
+++ b/src/pages/home/folder/Images.tsx
@@ -35,7 +35,9 @@ const ImageLayout = (props: { images: StoreObj[] }) => {
     >
       <Show when={local["show_count_msg"] === "visible"}>
         <Box w="100%" textAlign="left" pl="$2">
-          <Text>{smartCountMsg(ObjType.IMAGE)}</Text>
+          <Text size="sm" color="$neutral11">
+            {smartCountMsg(ObjType.IMAGE)}
+          </Text>
         </Box>
       </Show>
       <Show when={local["show_folder_in_image_view"] === "top"}>

--- a/src/pages/home/folder/Images.tsx
+++ b/src/pages/home/folder/Images.tsx
@@ -33,9 +33,6 @@ const ImageLayout = (props: { images: StoreObj[] }) => {
       spacing="$2"
       w="$full"
     >
-      <Box w="100%" textAlign="left" pl="$2">
-        <Text>{countMsg(ObjType.IMAGE)}</Text>
-      </Box>
       <Show when={local["show_folder_in_image_view"] === "top"}>
         {folders()}
       </Show>
@@ -53,6 +50,11 @@ const ImageLayout = (props: { images: StoreObj[] }) => {
       </Show>
       <Show when={local["show_folder_in_image_view"] === "bottom"}>
         {folders()}
+      </Show>
+      <Show when={local["show_count_msg"] === "visible"}>
+        <Text size="sm" color="$neutral11">
+          {countMsg()}
+        </Text>
       </Show>
     </VStack>
   )

--- a/src/pages/home/folder/Images.tsx
+++ b/src/pages/home/folder/Images.tsx
@@ -1,7 +1,7 @@
 import { Box, Flex, Grid, Heading, Text, VStack } from "@hope-ui/solid"
 import { For, Show, createMemo } from "solid-js"
 import { ImageItem } from "./ImageItem"
-import { countMsg, local, objStore } from "~/store"
+import { smartCountMsg, local, objStore } from "~/store"
 import { GridItem } from "./GridItem"
 import { ObjType, StoreObj } from "~/types"
 import { useT } from "~/hooks"
@@ -33,6 +33,11 @@ const ImageLayout = (props: { images: StoreObj[] }) => {
       spacing="$2"
       w="$full"
     >
+      <Show when={local["show_count_msg"] === "visible"}>
+        <Box w="100%" textAlign="left" pl="$2">
+          <Text>{smartCountMsg(ObjType.IMAGE)}</Text>
+        </Box>
+      </Show>
       <Show when={local["show_folder_in_image_view"] === "top"}>
         {folders()}
       </Show>
@@ -50,11 +55,6 @@ const ImageLayout = (props: { images: StoreObj[] }) => {
       </Show>
       <Show when={local["show_folder_in_image_view"] === "bottom"}>
         {folders()}
-      </Show>
-      <Show when={local["show_count_msg"] === "visible"}>
-        <Text size="sm" color="$neutral11">
-          {countMsg()}
-        </Text>
       </Show>
     </VStack>
   )

--- a/src/pages/home/folder/List.tsx
+++ b/src/pages/home/folder/List.tsx
@@ -13,6 +13,7 @@ import {
   checkboxOpen,
   countMsg,
   isIndeterminate,
+  local,
   objStore,
   selectAll,
   sortObjs,
@@ -67,7 +68,6 @@ export const ListTitle = (props: {
           />
         </Show>
         <Text {...itemProps(cols[0])}>{t(`home.obj.${cols[0].name}`)}</Text>
-        <Text {...itemProps(cols[0])}>{countMsg()}</Text>
       </HStack>
       <Text w={cols[1].w} {...itemProps(cols[1])}>
         {t(`home.obj.${cols[1].name}`)}
@@ -112,6 +112,11 @@ const ListLayout = () => {
           return <ListItem obj={obj} index={i()} />
         }}
       </For>
+      <Show when={local["show_count_msg"] === "visible"}>
+        <Text size="sm" color="$neutral11">
+          {countMsg()}
+        </Text>
+      </Show>
     </VStack>
   )
 }

--- a/src/pages/home/folder/List.tsx
+++ b/src/pages/home/folder/List.tsx
@@ -16,6 +16,7 @@ import {
   local,
   objStore,
   selectAll,
+  selectedMsg,
   sortObjs,
 } from "~/store"
 import { OrderBy } from "~/store"
@@ -67,7 +68,11 @@ export const ListTitle = (props: {
             }}
           />
         </Show>
-        <Text {...itemProps(cols[0])}>{t(`home.obj.${cols[0].name}`)}</Text>
+        {selectedMsg() ? (
+          <Text {...itemProps(cols[0])}>{selectedMsg()}</Text>
+        ) : (
+          <Text {...itemProps(cols[0])}>{t(`home.obj.${cols[0].name}`)}</Text>
+        )}
       </HStack>
       <Text w={cols[1].w} {...itemProps(cols[1])}>
         {t(`home.obj.${cols[1].name}`)}

--- a/src/store/local_settings.ts
+++ b/src/store/local_settings.ts
@@ -37,6 +37,12 @@ export const initialLocalSettings = [
     options: ["none", "visible"],
   },
   {
+    key: "show_count_msg",
+    default: "none",
+    type: "select",
+    options: ["none", "visible"],
+  },
+  {
     key: "position_of_header_navbar",
     default: "static",
     type: "select",

--- a/src/store/obj.ts
+++ b/src/store/obj.ts
@@ -224,11 +224,22 @@ export const setPassword = (password: string) => {
   cookieStorage.setItem("browser-password", password)
 }
 
-const getCountStr = (objs: StoreObj[], prefix: string) => {
+const getCountStr = (
+  objs: StoreObj[],
+  prefix: string,
+  filterType?: ObjType,
+) => {
   const t = useT()
+
+  if (filterType) {
+    objs = objs.filter((obj) => obj.is_dir || obj.type === filterType)
+  }
+
+  if (objs.length === 0) return ""
+
   const folders = objs.filter((o) => o.is_dir).length
   const files = objs.length - folders
-  const vars = { folders: `${folders}`, files: `${files}` }
+  const vars = { folders: folders.toString(), files: files.toString() }
   const key =
     folders && files
       ? `${prefix}`
@@ -240,32 +251,21 @@ const getCountStr = (objs: StoreObj[], prefix: string) => {
   return key ? t(`home.obj.count.${key}`, vars) : ""
 }
 
-export const countMsg = (filterType?: ObjType) => {
-  let objs = objStore.objs
-  if (filterType) {
-    objs = objs.filter((obj) => obj.is_dir || obj.type === filterType)
-  }
-
-  return getCountStr(objs, "count")
-}
+export const countMsg = (filterType?: ObjType) =>
+  getCountStr(objStore.objs, "count", filterType)
 
 export const selectedMsg = (filterType?: ObjType) => {
   const selectedList = selectedObjs()
   const isSelected = selectedList.length > 0
 
-  if (!isSelected) return ""
-
-  let objs = selectedList
-  if (filterType) {
-    objs = objs.filter((obj) => obj.is_dir || obj.type === filterType)
-  }
-
-  return getCountStr(objs, "selected")
+  return isSelected ? getCountStr(selectedList, "selected", filterType) : ""
 }
 
 export const smartCountMsg = (filterType?: ObjType) => {
   const selectedList = selectedObjs()
   const isSelected = selectedList.length > 0
 
-  return isSelected ? selectedMsg(filterType) : countMsg(filterType)
+  return isSelected
+    ? getCountStr(selectedList, "selected", filterType)
+    : countMsg(filterType)
 }

--- a/src/store/obj.ts
+++ b/src/store/obj.ts
@@ -224,22 +224,11 @@ export const setPassword = (password: string) => {
   cookieStorage.setItem("browser-password", password)
 }
 
-export const countMsg = (filterType?: ObjType) => {
+const getCountStr = (objs: StoreObj[], prefix: string) => {
   const t = useT()
-  const selectedList = selectedObjs()
-  const isSelected = selectedList.length > 0
-  let objs = isSelected ? selectedList : objStore.objs
-
-  if (filterType) {
-    objs = objs.filter((obj) => obj.is_dir || obj.type === filterType)
-  }
-
   const folders = objs.filter((o) => o.is_dir).length
   const files = objs.length - folders
-
   const vars = { folders: `${folders}`, files: `${files}` }
-  const prefix = isSelected ? "selected" : "count"
-
   const key =
     folders && files
       ? `${prefix}`
@@ -249,4 +238,34 @@ export const countMsg = (filterType?: ObjType) => {
           ? `${prefix}_files`
           : ""
   return key ? t(`home.obj.count.${key}`, vars) : ""
+}
+
+export const countMsg = (filterType?: ObjType) => {
+  let objs = objStore.objs
+  if (filterType) {
+    objs = objs.filter((obj) => obj.is_dir || obj.type === filterType)
+  }
+
+  return getCountStr(objs, "count")
+}
+
+export const selectedMsg = (filterType?: ObjType) => {
+  const selectedList = selectedObjs()
+  const isSelected = selectedList.length > 0
+
+  if (!isSelected) return ""
+
+  let objs = selectedList
+  if (filterType) {
+    objs = objs.filter((obj) => obj.is_dir || obj.type === filterType)
+  }
+
+  return getCountStr(objs, "selected")
+}
+
+export const smartCountMsg = (filterType?: ObjType) => {
+  const selectedList = selectedObjs()
+  const isSelected = selectedList.length > 0
+
+  return isSelected ? selectedMsg(filterType) : countMsg(filterType)
 }


### PR DESCRIPTION
基于社区反馈，此 PR 对文件数量显示功能进行了调整：将显示位置移至列表底部，并新增设置选项供用户自定义开启/关闭，默认状态为关闭

![](https://github.com/user-attachments/assets/70b33aa6-d63a-489e-8acd-83432339ecf3)

文档：https://github.com/OpenListTeam/OpenList-Docs/pull/101

对于 List 视图，将已选中项按照 #31 的建议替换到名称栏显示，由于不影响正常观感，不受设置项控制

Close: #31 

Close: #53 
