### PR TITLE
fix(audio): try to fix error when lrc is empty

### DIFF
--- a/src/pages/home/previews/audio.tsx
+++ b/src/pages/home/previews/audio.tsx
@@ -73,6 +73,16 @@ const Preview = () => {
       lrcType: objStore.provider === "NeteaseMusic" ? 1 : 3,
       audio: audios.map(objToAudio),
     })
+
+    // Apply monkey patch to fix https://github.com/DIYgod/APlayer/issues/283
+    const _switch = ap.lrc.switch
+    const _update = ap.lrc.update
+    ap.lrc.switch = (index: any) => {
+      ap.lrc.update = () => {}
+      _switch.call(ap.lrc, index)
+      ap.lrc.update = _update
+    }
+
     if (objStore.provider === "NeteaseMusic") {
       ap.on("loadstart", () => {
         const i = ap.list.index


### PR DESCRIPTION
Add the monkey patch from `https://github.com/DIYgod/APlayer/issues/283#issuecomment-1975920710` .

Close: #97 

