### PR TITLE
chore(deps): update Monaco Editor cdn to 0.52.2

### DIFF
--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -27,4 +27,4 @@ if (api.endsWith("/")) {
 
 export const monaco_cdn =
   window.OPENLIST_CONFIG.monaco_cdn ||
-  "https://lf3-cdn-tos.bytecdntp.com/cdn/expire-1-M/monaco-editor/0.33.0-dev.20220228/min/vs"
+  "https://registry.npmmirror.com/monaco-editor/0.52.2/files/min/vs"


### PR DESCRIPTION
The previous ByteDance CDN had synchronization issues. This PR switches to npmmirror and updates to version 0.52.2.