### PR TITLE
refactor(assets): migrate to resource domain

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,10 +11,7 @@
     <link href="/static/manifest.json" rel="manifest" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-title" content="OpenList" />
-    <link
-      rel="apple-touch-icon"
-      href="https://cdn.oplist.org/gh/OpenListTeam/Logo@main/logo.png"
-    />
+    <link rel="apple-touch-icon" href="https://res.oplist.org/logo/logo.png" />
     <script
       src="https://g.alicdn.com/IMM/office-js/1.1.5/aliyun-web-office-sdk.min.js"
       async
@@ -22,7 +19,7 @@
     <link
       rel="shortcut icon"
       type="image/ico"
-      href="https://cdn.oplist.org/gh/OpenListTeam/Logo@main/logo.svg"
+      href="https://res.oplist.org/logo/logo.svg"
     />
     <title>Loading...</title>
     <script>

--- a/public/static/manifest.json
+++ b/public/static/manifest.json
@@ -5,7 +5,7 @@
   "name": "OpenList",
   "icons": [
     {
-      "src": "https://cdn.oplist.org/gh/OpenListTeam/Logo@main/logo/512x512.png",
+      "src": "https://res.oplist.org/logo/512x512.png",
       "sizes": "512x512",
       "type": "image/png"
     }

--- a/src/pages/home/previews/audio.tsx
+++ b/src/pages/home/previews/audio.tsx
@@ -40,7 +40,7 @@ const Preview = () => {
       cover =
         obj.thumb ||
         getSetting("audio_cover") ||
-        "https://cdn.oplist.org/gh/OpenListTeam/Logo@main/logo.svg"
+        "https://res.oplist.org/logo/logo.svg"
     }
     const audio = {
       name: obj.name,

--- a/src/pages/manage/About.tsx
+++ b/src/pages/manage/About.tsx
@@ -5,7 +5,7 @@ import { useT, useManageTitle } from "~/hooks"
 const fetchReadme = async () =>
   await (
     await fetch(
-      "https://cdn.statically.io/gh/OpenListTeam/OpenList/main/README.md",
+      "https://raw.githubusercontent.com/OpenListTeam/OpenList/main/README.md",
     )
   ).text()
 


### PR DESCRIPTION
将 Logo 的 CDN 迁移至静态资源域名，减少对 Worker API 服务的请求数