### PR TITLE
fix(pdfjs): use legacy pdfjs-dist for compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,5 +111,10 @@
   },
   "lint-staged": {
     "**/*.{js,ts,css,tsx,jsx,md,html,yml,yaml}": "prettier --write"
+  },
+  "pnpm": {
+    "patchedDependencies": {
+      "@pdfslick/core@3.0.0": "patches/@pdfslick__core@3.0.0.patch"
+    }
   }
 }

--- a/patches/@pdfslick__core@3.0.0.patch
+++ b/patches/@pdfslick__core@3.0.0.patch
@@ -1,0 +1,33 @@
+diff --git a/dist/esm/index.js b/dist/esm/index.js
+index b1838349fa9644aa6034b1e88b00f8668d242994..fcac95798e8336abe60ab0d8527cb1dc7170ca3c 100644
+--- a/dist/esm/index.js
++++ b/dist/esm/index.js
+@@ -1,5 +1,5 @@
+ import { RenderingCancelledException, PixelsPerInch, getXfaPageViewport, AnnotationMode, AnnotationEditorType, GlobalWorkerOptions, AnnotationEditorParamsType, getPdfFilenameFromUrl, getDocument, PDFDateString } from 'pdfjs-dist';
+-import { SimpleLinkService, XfaLayerBuilder, GenericL10n, DownloadManager, EventBus, PDFLinkService, PDFFindController, PDFSinglePageViewer, PDFViewer } from 'pdfjs-dist/web/pdf_viewer.mjs';
++import { SimpleLinkService, XfaLayerBuilder, GenericL10n, DownloadManager, EventBus, PDFLinkService, PDFFindController, PDFSinglePageViewer, PDFViewer } from 'pdfjs-dist/legacy/web/pdf_viewer.mjs';
+ import { createStore } from 'zustand/vanilla';
+ 
+ /******************************************************************************
+@@ -2417,7 +2417,7 @@ class PDFSlickPrintDialog {
+ }
+ 
+ var _PDFSlick_instances, _PDFSlick_renderingQueue, _PDFSlick_container, _PDFSlick_viewerContainer, _PDFSlick_thumbsContainer, _PDFSlick_printService, _PDFSlick_annotationMode, _PDFSlick_annotationEditorMode, _PDFSlick_onError, _PDFSlick_eventAbortController, _PDFSlick_initializePageLabels, _PDFSlick_parseDocumentInfo, _PDFSlick_parsePageSize, _PDFSlick_initInternalEventListeners, _PDFSlick_onDocumentReady, _PDFSlick_onRotationChanging, _PDFSlick_onSwitchSpreadMode, _PDFSlick_onSwitchScrollMode, _PDFSlick_onScaleChanging, _PDFSlick_onPageChanging, _PDFSlick_onPageRendered;
+-GlobalWorkerOptions.workerSrc = new URL('pdfjs-dist/build/pdf.worker.min.mjs', import.meta.url).toString();
++GlobalWorkerOptions.workerSrc = new URL('pdfjs-dist/legacy/build/pdf.worker.min.mjs', import.meta.url).toString();
+ const US_PAGE_NAMES = {
+     "8.5x11": "Letter",
+     "8.5x14": "Legal",
+diff --git a/package.json b/package.json
+index 3962cc752d8ca79e5985133c0fdc0a7f6f6b9949..720d2b3beb1bce96f6ce47d90dda6e376ced9f0a 100644
+--- a/package.json
++++ b/package.json
+@@ -42,7 +42,7 @@
+     "dev": "concurrently \"rollup --config node:@pdfslick/rollup-config --watch\" \"npm run css-watch\"",
+     "devdev": "rollup --config node:@pdfslick/rollup-config && npm run css",
+     "build": "rollup --config node:@pdfslick/rollup-config --environment NODE_ENV:production && npm run css",
+-    "css": "cat ../../node_modules/pdfjs-dist/web/pdf_viewer.css ./styles/pdf_viewer.css | postcss -o dist/pdf_viewer.css",
++    "css": "cat ../../node_modules/pdfjs-dist/legacy/web/pdf_viewer.css ./styles/pdf_viewer.css | postcss -o dist/pdf_viewer.css",
+     "css-watch": "npm run css",
+     "css-js": "node combine-css.js",
+     "css-watch-js": "npm run css -- --watch"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  '@pdfslick/core@3.0.0':
+    hash: h4ua6dncpwke4tlcj36t6o7tvm
+    path: patches/@pdfslick__core@3.0.0.patch
+
 importers:
 
   .:
@@ -1032,35 +1037,30 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/canvas-linux-arm64-musl@0.1.74':
     resolution: {integrity: sha512-tfFqLHGtSEabBigOnPUfZviSTGmW2xHv5tYZYPBWmgGiTkoNJ7lEWFUxHjwvV5HXGqLs8ok/O7g1enSpxO6lmQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@napi-rs/canvas-linux-riscv64-gnu@0.1.74':
     resolution: {integrity: sha512-j6H9dHTMtr1y3tu/zGm1ythYIL9vTl4EEv9f6CMx0n3Zn2M+OruUUwh9ylCj4afzSNEK9T8cr6zMnmTPzkpBvQ==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/canvas-linux-x64-gnu@0.1.74':
     resolution: {integrity: sha512-73DIV4E7Y9CpIJuUXVl9H6+MEQXyRy4VJQoUGA1tOlcKQiStxqhq6UErL4decI28NxjyQXBhtYZKj5q8AJEuOg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/canvas-linux-x64-musl@0.1.74':
     resolution: {integrity: sha512-FgDMEFdGIJT3I2xejflRJ82/ZgDphyirS43RgtoLaIXI6zihLiZcQ7rczpqeWgAwlJNjR0He2EustsKe1SkUOg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@napi-rs/canvas-win32-x64-msvc@0.1.74':
     resolution: {integrity: sha512-x6bhwlhn0wU7dfiP46mt5Bi6PowSUH4CJ4PTzGj58LRQ1HVasEIJgoMx7MLC48F738eJpzbfg3WR/D8+e9CeTA==}
@@ -1114,67 +1114,56 @@ packages:
     resolution: {integrity: sha512-RkdOTu2jK7brlu+ZwjMIZfdV2sSYHK2qR08FUWcIoqJC2eywHbXr0L8T/pONFwkGukQqERDheaGTeedG+rra6Q==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.45.1':
     resolution: {integrity: sha512-3kJ8pgfBt6CIIr1o+HQA7OZ9mp/zDk3ctekGl9qn/pRBgrRgfwiffaUmqioUGN9hv0OHv2gxmvdKOkARCtRb8Q==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.45.1':
     resolution: {integrity: sha512-k3dOKCfIVixWjG7OXTCOmDfJj3vbdhN0QYEqB+OuGArOChek22hn7Uy5A/gTDNAcCy5v2YcXRJ/Qcnm4/ma1xw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.45.1':
     resolution: {integrity: sha512-PmI1vxQetnM58ZmDFl9/Uk2lpBBby6B6rF4muJc65uZbxCs0EA7hhKCk2PKlmZKuyVSHAyIw3+/SiuMLxKxWog==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.45.1':
     resolution: {integrity: sha512-9UmI0VzGmNJ28ibHW2GpE2nF0PBQqsyiS4kcJ5vK+wuwGnV5RlqdczVocDSUfGX/Na7/XINRVoUgJyFIgipoRg==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.45.1':
     resolution: {integrity: sha512-7nR2KY8oEOUTD3pBAxIBBbZr0U7U+R9HDTPNy+5nVVHDXI4ikYniH1oxQz9VoB5PbBU1CZuDGHkLJkd3zLMWsg==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.45.1':
     resolution: {integrity: sha512-nlcl3jgUultKROfZijKjRQLUu9Ma0PeNv/VFHkZiKbXTBQXhpytS8CIj5/NfBeECZtY2FJQubm6ltIxm/ftxpw==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.45.1':
     resolution: {integrity: sha512-HJV65KLS51rW0VY6rvZkiieiBnurSzpzore1bMKAhunQiECPuxsROvyeaot/tcK3A3aGnI+qTHqisrpSgQrpgA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.45.1':
     resolution: {integrity: sha512-NITBOCv3Qqc6hhwFt7jLV78VEO/il4YcBzoMGGNxznLgRQf43VQDae0aAzKiBeEPIxnDrACiMgbqjuihx08OOw==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.45.1':
     resolution: {integrity: sha512-+E/lYl6qu1zqgPEnTrs4WysQtvc/Sh4fC2nByfFExqgYrqkKWp1tWIbe+ELhixnenSpBbLXNi6vbEEJ8M7fiHw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.45.1':
     resolution: {integrity: sha512-a6WIAp89p3kpNoYStITT9RbTbTnqarU7D8N8F2CV+4Cl9fwCOZraLVuVFvlpsW0SbIiYtEnhCZBPLoNdRkjQFw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.45.1':
     resolution: {integrity: sha512-T5Bi/NS3fQiJeYdGvRpTAP5P02kqSOpqiopwhj0uaXB6nzs5JVi2XMJb18JUSKhCOX8+UE1UKQufyD6Or48dJg==}
@@ -1295,28 +1284,24 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.12.14':
     resolution: {integrity: sha512-ZkOOIpSMXuPAjfOXEIAEQcrPOgLi6CaXvA5W+GYnpIpFG21Nd0qb0WbwFRv4K8BRtl993Q21v0gPpOaFHU+wdA==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-linux-x64-gnu@1.12.14':
     resolution: {integrity: sha512-71EPPccwJiJUxd2aMwNlTfom2mqWEWYGdbeTju01tzSHsEuD7E6ePlgC3P3ngBqB3urj41qKs87z7zPOswT5Iw==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.12.14':
     resolution: {integrity: sha512-nImF1hZJqKTcl0WWjHqlelOhvuB9rU9kHIw/CmISBUZXogjLIvGyop1TtJNz0ULcz2Oxr3Q2YpwfrzsgvgbGkA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.12.14':
     resolution: {integrity: sha512-sABFQFxSuStFoxvEWZUHWYldtB1B4A9eDNFd4Ty50q7cemxp7uoscFoaCqfXSGNBwwBwpS5EiPB6YN4y6hqmLQ==}
@@ -4332,7 +4317,7 @@ snapshots:
       '@napi-rs/canvas-win32-x64-msvc': 0.1.74
     optional: true
 
-  '@pdfslick/core@3.0.0':
+  '@pdfslick/core@3.0.0(patch_hash=h4ua6dncpwke4tlcj36t6o7tvm)':
     dependencies:
       pdfjs-dist: 5.4.54
       zustand: 5.0.5
@@ -4344,7 +4329,7 @@ snapshots:
 
   '@pdfslick/solid@3.0.0(solid-js@1.9.7)':
     dependencies:
-      '@pdfslick/core': 3.0.0
+      '@pdfslick/core': 3.0.0(patch_hash=h4ua6dncpwke4tlcj36t6o7tvm)
       '@solid-primitives/resize-observer': 2.1.1(solid-js@1.9.7)
       solid-js: 1.9.7
     transitivePeerDependencies:


### PR DESCRIPTION
Fix: https://github.com/OpenListTeam/OpenList/issues/988

由于 pdfjs-dist 为打包后产物，而且是相对路径引用，不会被 @vitejs/plugin-legacy 进行 polyfill 处理，与我们的 vite 配置无关。

鉴于 pdfjs-dist 经常会加一些连自家浏览器都不支持的功能，在生产环境还是使用它的 legacy 为好。

此 PR 使用 pnpm patch 了 `@pdfslick/core@3.0.0`，让它强制使用 legacy。

实测在 Windows 7 + Chrome 109 下能够正常使用。