### PR TITLE
feat(editor): Add configurable font size

### DIFF
--- a/src/components/MonacoEditor.tsx
+++ b/src/components/MonacoEditor.tsx
@@ -4,6 +4,7 @@ import { MaybeLoading } from "./FullLoading"
 import loader from "@monaco-editor/loader"
 import { useCDN } from "~/hooks"
 import type * as monacoType from "monaco-editor/esm/vs/editor/editor.api"
+import { local } from "~/store"
 
 export interface MonacoEditorProps {
   value: string
@@ -42,6 +43,7 @@ export const MonacoEditor = (props: MonacoEditorProps) => {
     monacoEditor = monaco.editor.create(monacoEditorDiv!, {
       value: props.value,
       theme: props.theme,
+      fontSize: parseInt(local.editor_font_size),
     })
     model = monaco.editor.createModel(
       props.value,
@@ -60,6 +62,13 @@ export const MonacoEditor = (props: MonacoEditorProps) => {
   createEffect(() => {
     monaco.editor.setTheme(props.theme)
   })
+
+  createEffect(() => {
+    monacoEditor?.updateOptions({
+      fontSize: parseInt(local.editor_font_size),
+    })
+  })
+
   onCleanup(() => {
     model && model.dispose()
     monacoEditor && monacoEditor.dispose()

--- a/src/pages/home/toolbar/LocalSettings.tsx
+++ b/src/pages/home/toolbar/LocalSettings.tsx
@@ -23,8 +23,10 @@ import {
   SelectValue,
   VStack,
   Switch as HopeSwitch,
+  IconButton,
 } from "@hope-ui/solid"
 import { For, Match, onCleanup, Switch } from "solid-js"
+import { FaSolidMinus, FaSolidPlus } from "solid-icons/fa"
 import { SwitchLanguageWhite, SwitchColorMode } from "~/components"
 import { useT } from "~/hooks"
 import { initialLocalSettings, local, LocalSetting, setLocal } from "~/store"
@@ -79,6 +81,40 @@ function LocalSettingEdit(props: LocalSetting) {
               setLocal(props.key, e.currentTarget.checked.toString())
             }}
           />
+        </Match>
+        <Match when={props.type === "number"}>
+          <HStack>
+            <IconButton
+              aria-label="decrease"
+              icon={<FaSolidMinus />}
+              onClick={() => {
+                setLocal(
+                  props.key,
+                  Math.max(1, parseInt(local[props.key]) - 1).toString(),
+                )
+              }}
+            />
+            <Input
+              type="number"
+              value={local[props.key]}
+              onInput={(e) => {
+                setLocal(props.key, e.currentTarget.value)
+              }}
+              style={{
+                "-moz-appearance": "textfield",
+                "::-webkit-inner-spin-button": { display: "none" },
+                "::-webkit-outer-spin-button": { display: "none" },
+              }}
+              class="hide-spin"
+            />
+            <IconButton
+              aria-label="increase"
+              icon={<FaSolidPlus />}
+              onClick={() => {
+                setLocal(props.key, (parseInt(local[props.key]) + 1).toString())
+              }}
+            />
+          </HStack>
         </Match>
       </Switch>
     </FormControl>

--- a/src/store/local_settings.ts
+++ b/src/store/local_settings.ts
@@ -66,6 +66,11 @@ export const initialLocalSettings = [
     options: ["direct", "dblclick", "disable_while_checked"],
     hidden: false,
   },
+  {
+    key: "editor_font_size",
+    default: "14",
+    type: "number",
+  },
 ]
 export type LocalSetting = (typeof initialLocalSettings)[number]
 for (const setting of initialLocalSettings) {


### PR DESCRIPTION
<!--
  Provide a general summary of your changes in the Title above.
  The PR title must start with `feat(): `, `docs(): `, `fix(): `, `style(): `, or `refactor(): `, `chore(): `. For example: `feat(component): add new feature`.
  If it spans multiple components, use the main component as the prefix and enumerate in the title, describe in the body.
-->
<!--
  在上方标题中提供您更改的总体摘要。
  PR 标题需以 `feat(): `, `docs(): `, `fix(): `, `style(): `, `refactor(): `, `chore(): ` 其中之一开头，例如：`feat(component): 新增功能`。
  如果跨多个组件，请使用主要组件作为前缀，并在标题中枚举、描述中说明。
-->

## Description / 描述

<!-- Describe your changes in detail -->
<!-- 详细描述您的更改 -->

This commit introduces a new local setting to allow users to customize the font size in the Monaco editor.

- Adds an editor_font_size setting to the local store with a default of 14.

- Implements a number input with increment/decrement buttons in the Local Settings panel to modify the font size.

- The MonacoEditor component now reads this value to set its font size and updates dynamically when the setting is changed.

<img width="291" height="313" alt="firefox_CO1Fj69La4" src="https://github.com/user-attachments/assets/4186de4a-d517-41b5-8ba4-c6af85489f9e" />

## Motivation and Context / 背景

<!-- Why is this change required? What problem does it solve? -->
<!-- 为什么需要此更改？它解决了什么问题？ -->

<!-- If it fixes an open issue, please link to the issue here. -->
<!-- 如果修复了一个打开的issue，请在此处链接到该issue -->

Closes #XXXX

<!-- or -->
<!-- 或者 -->

Relates to #XXXX

## How Has This Been Tested? / 测试

<!-- Please describe in detail how you tested your changes. -->
<!-- 请详细描述您如何测试更改 -->

## Checklist / 检查清单

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- 检查以下所有要点，并在所有适用的框中打`x` -->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- 如果您对其中任何一项不确定，请不要犹豫提问。我们会帮助您！ -->

- [x] I have read the [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md) document.
      我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md) 文档。
- [x] I have formatted my code with `go fmt` or [prettier](https://prettier.io/).
      我已使用 `go fmt` 或 [prettier](https://prettier.io/) 格式化提交的代码。
- [x] I have added appropriate labels to this PR (or mentioned needed labels in the description if lacking permissions).
      我已为此 PR 添加了适当的标签（如无权限或需要的标签不存在，请在描述中说明，管理员将后续处理）。
- [ ] I have requested review from relevant code authors using the "Request review" feature when applicable.
      我已在适当情况下使用"Request review"功能请求相关代码作者进行审查。
- [ ] I have updated the repository accordingly (If it’s needed).
      我已相应更新了相关仓库（若适用）。
  - [ ] [OpenList-Frontend](https://github.com/OpenListTeam/OpenList-Frontend) #XXXX
  - [ ] [OpenList-Docs](https://github.com/OpenListTeam/OpenList-Docs) #XXXX
