### PR TITLE
feat(share): add placeholder and increment format for expire date input

### DIFF
--- a/src/pages/home/toolbar/Share.tsx
+++ b/src/pages/home/toolbar/Share.tsx
@@ -1,6 +1,7 @@
 import { useFetch, useRouter, useT, useUtil } from "~/hooks"
 import {
   bus,
+  getExpireDate,
   handleResp,
   makeTemplateData,
   matchTemplate,
@@ -224,6 +225,7 @@ export const Share = () => {
                   size="sm"
                   invalid={!expireValid()}
                   value={expireString()}
+                  placeholder="yyyy-MM-dd HH:mm:ss or +1w1d1H1m1s1ms"
                   onInput={(e) => {
                     setExpireString(e.currentTarget.value)
                     if (e.currentTarget.value === "") {
@@ -231,7 +233,7 @@ export const Share = () => {
                       setShare("expires", null)
                       return
                     }
-                    const date = new Date(e.currentTarget.value)
+                    const date = getExpireDate(e.currentTarget.value)
                     if (isNaN(date.getTime())) {
                       setExpireValid(false)
                     } else {

--- a/src/pages/manage/shares/AddOrEdit.tsx
+++ b/src/pages/manage/shares/AddOrEdit.tsx
@@ -1,13 +1,6 @@
 import { useFetch, useRouter, useT } from "~/hooks"
-import {
-  OrderDirection,
-  PResp,
-  Share,
-  ShareInfo,
-  ShareUpdate,
-  Type,
-} from "~/types"
-import { handleResp, notify, r, randomPwd } from "~/utils"
+import { PResp, Share, ShareInfo, ShareUpdate, Type } from "~/types"
+import { handleResp, notify, r, randomPwd, getExpireDate } from "~/utils"
 import { createStore } from "solid-js/store"
 import { Button, Heading } from "@hope-ui/solid"
 import { MaybeLoading } from "~/components"
@@ -140,6 +133,7 @@ const AddOrEdit = () => {
           type={Type.String}
           value={expireString()}
           valid={expireValid()}
+          placeholder="yyyy-MM-dd HH:mm:ss or +1w1d1H1m1s1ms"
           onChange={(e) => {
             setExpireString(e)
             if (e === "") {
@@ -147,7 +141,7 @@ const AddOrEdit = () => {
               setShare("expires", null)
               return
             }
-            const date = new Date(e)
+            const date = getExpireDate(e)
             if (isNaN(date.getTime())) {
               setExpireValid(false)
             } else {

--- a/src/pages/manage/shares/Item.tsx
+++ b/src/pages/manage/shares/Item.tsx
@@ -23,6 +23,7 @@ export type ItemProps = {
   options?: string
   options_prefix?: string
   valid?: boolean
+  placeholder?: string
 } & (
   | {
       type: Type.Bool
@@ -74,6 +75,7 @@ const Item = (props: ItemProps) => {
               readOnly={props.readonly}
               value={props.value as string}
               invalid={!props.valid}
+              placeholder={props.placeholder}
               onChange={
                 props.type === Type.String
                   ? (e) => props.onChange?.(e.currentTarget.value)
@@ -101,6 +103,7 @@ const Item = (props: ItemProps) => {
             readOnly={props.readonly}
             value={props.value as number}
             invalid={!props.valid}
+            placeholder={props.placeholder}
             onInput={
               props.type === Type.Number
                 ? (e) => props.onChange?.(parseInt(e.currentTarget.value))
@@ -115,6 +118,7 @@ const Item = (props: ItemProps) => {
             readOnly={props.readonly}
             value={props.value as number}
             invalid={!props.valid}
+            placeholder={props.placeholder}
             onInput={
               props.type === Type.Float
                 ? (e) => props.onChange?.(parseFloat(e.currentTarget.value))
@@ -141,6 +145,7 @@ const Item = (props: ItemProps) => {
             readOnly={props.readonly}
             value={props.value as string}
             invalid={!props.valid}
+            placeholder={props.placeholder}
             onChange={
               props.type === Type.Text
                 ? (e) => props.onChange?.(e.currentTarget.value)

--- a/src/utils/share.ts
+++ b/src/utils/share.ts
@@ -23,7 +23,7 @@ export const makeTemplateData = (
 }
 
 const expireDateIncrementRegExp =
-  /^\+(?:(\d+)w)?(?:(\d+)d)?(?:(\d+)H)?(?:(\d+)m)?(?:(\d+)s)?(?:(\d+)ms)?$/
+  /^\+(?=\d+[wdHms])(?:(\d+)w)?(?:(\d+)d)?(?:(\d+)H)?(?:(\d+)m)?(?:(\d+)s)?(?:(\d+)ms)?$/
 
 const toInt = (s: string | undefined) => {
   if (s === undefined) return 0
@@ -40,9 +40,7 @@ export const getExpireDate = (dateStr: string) => {
     const m = toInt(match[4]) + H * 60
     const s = toInt(match[5]) + m * 60
     const ms = toInt(match[6]) + s * 1000
-    let date = new Date()
-    date.setTime(date.getTime() + ms)
-    return date
+    return new Date(Date.now() + ms)
   } else {
     return new Date(dateStr)
   }

--- a/src/utils/share.ts
+++ b/src/utils/share.ts
@@ -21,3 +21,29 @@ export const makeTemplateData = (
     ...other,
   }
 }
+
+const expireDateIncrementRegExp =
+  /^\+(?:(\d+)w)?(?:(\d+)d)?(?:(\d+)H)?(?:(\d+)m)?(?:(\d+)s)?(?:(\d+)ms)?$/
+
+const toInt = (s: string | undefined) => {
+  if (s === undefined) return 0
+  const n = Number.parseInt(s)
+  return Number.isNaN(n) ? 0 : n
+}
+
+export const getExpireDate = (dateStr: string) => {
+  const match = expireDateIncrementRegExp.exec(dateStr)
+  if (match) {
+    const w = toInt(match[1])
+    const d = toInt(match[2]) + w * 7
+    const H = toInt(match[3]) + d * 24
+    const m = toInt(match[4]) + H * 60
+    const s = toInt(match[5]) + m * 60
+    const ms = toInt(match[6]) + s * 1000
+    let date = new Date()
+    date.setTime(date.getTime() + ms)
+    return date
+  } else {
+    return new Date(dateStr)
+  }
+}


### PR DESCRIPTION
## Description / 描述

1. 为创建分享页面的过期时间输入框增加了输入格式 placeholder。
2. 增加时限格式支持，使用`+1w1d1H1m1s1ms`这样的格式表示共享有效时长，如`+1d`表示1天后过期，`+1w100m`表示1周零100分钟后过期。

## Motivation and Context / 背景

Closes OpenListTeam/OpenList#1239

## Checklist / 检查清单

- [x] I have read the [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md) document.
      我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md) 文档。
- [x] I have formatted my code with `go fmt` or [prettier](https://prettier.io/).
      我已使用 `go fmt` 或 [prettier](https://prettier.io/) 格式化提交的代码。
- [x] I have added appropriate labels to this PR (or mentioned needed labels in the description if lacking permissions).
      我已为此 PR 添加了适当的标签（如无权限或需要的标签不存在，请在描述中说明，管理员将后续处理）。
- [ ] I have requested review from relevant code authors using the "Request review" feature when applicable.
      我已在适当情况下使用"Request review"功能请求相关代码作者进行审查。
- [ ] I have updated the repository accordingly (If it’s needed).
      我已相应更新了相关仓库（若适用）。
  - [x] [OpenList-Frontend](https://github.com/OpenListTeam/OpenList-Frontend) #XXXX
  - [ ] [OpenList-Docs](https://github.com/OpenListTeam/OpenList-Docs) #XXXX
