### PR TITLE
style(disk-usage): add an option to show disk usage in plain text

### DIFF
--- a/src/pages/home/folder/ListItem.tsx
+++ b/src/pages/home/folder/ListItem.tsx
@@ -14,6 +14,7 @@ import { usePath, useRouter, useUtil } from "~/hooks"
 import {
   checkboxOpen,
   getMainColor,
+  getSettingBool,
   local,
   OrderBy,
   selectIndex,
@@ -173,24 +174,37 @@ export const ListItem = (props: { obj: StoreObj; index: number }) => {
           }
           when={showDiskUsage(props.obj.mount_details)}
         >
-          <Progress
-            w={cols[1].w}
-            class="disk-usage-percentage"
-            trackColor="$info3"
-            rounded="$full"
-            size="md"
-            value={usedPercentage(props.obj.mount_details!)}
+          <Show
+            fallback={
+              <Text
+                class="size"
+                w={cols[1].w}
+                textAlign={cols[1].textAlign as any}
+              >
+                {toReadableUsage(props.obj.mount_details!)}
+              </Text>
+            }
+            when={!getSettingBool("show_disk_usage_in_plain_text")}
           >
-            <ProgressIndicator
-              color={
-                nearlyFull(props.obj.mount_details!) ? "$danger6" : "$info6"
-              }
-              rounded="$md"
-            />
-            <ProgressLabel class="disk-usage-text">
-              {toReadableUsage(props.obj.mount_details!)}
-            </ProgressLabel>
-          </Progress>
+            <Progress
+              w={cols[1].w}
+              class="disk-usage-percentage"
+              trackColor="$info3"
+              rounded="$full"
+              size="md"
+              value={usedPercentage(props.obj.mount_details!)}
+            >
+              <ProgressIndicator
+                color={
+                  nearlyFull(props.obj.mount_details!) ? "$danger6" : "$info6"
+                }
+                rounded="$md"
+              />
+              <ProgressLabel class="disk-usage-text">
+                {toReadableUsage(props.obj.mount_details!)}
+              </ProgressLabel>
+            </Progress>
+          </Show>
         </Show>
         <Text
           class="modified"

--- a/src/pages/manage/tasks/Task.tsx
+++ b/src/pages/manage/tasks/Task.tsx
@@ -143,7 +143,7 @@ export const Task = (props: TaskAttribute & TasksProps & TaskLocalSetter) => {
   let speedText = "-"
   const parseSpeedText = (timeDelta: number, lengthDelta: number) => {
     let delta = lengthDelta / timeDelta
-    const units = ["B/s", "KiB/s", "MiB/s", "GiB/s", "TiB/s"]
+    const units = ["B/s", "KiB/s", "MiB/s", "GiB/s", "TiB/s", "PiB/s", "EiB/s"]
     const k = 1024
     let unit_i = 0
     while (unit_i < units.length - 1 && delta >= k) {

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -13,7 +13,7 @@ export const showDiskUsage = (details: MountDetails | undefined) => {
 export const toReadableUsage = (details: MountDetails) => {
   let total = details.total_space!
   let used = total - details.free_space!
-  const units = ["B", "KiB", "MiB", "GiB", "TiB", "PiB"]
+  const units = ["B", "KB", "MB", "GB", "TB", "PB"]
   const k = 1024
   let unit_i = 0
   while (unit_i < units.length - 1 && (used >= k || total >= k)) {

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -13,7 +13,7 @@ export const showDiskUsage = (details: MountDetails | undefined) => {
 export const toReadableUsage = (details: MountDetails) => {
   let total = details.total_space!
   let used = total - details.free_space!
-  const units = ["B", "KB", "MB", "GB", "TB", "PB"]
+  const units = ["B", "K", "M", "G", "T", "P", "E"]
   const k = 1024
   let unit_i = 0
   while (unit_i < units.length - 1 && (used >= k || total >= k)) {


### PR DESCRIPTION
## Description / 描述

后端：OpenListTeam/OpenList#1326

- [x] I have read the [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md) document.
      我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md) 文档。
- [x] I have formatted my code with `go fmt` or [prettier](https://prettier.io/).
      我已使用 `go fmt` 或 [prettier](https://prettier.io/) 格式化提交的代码。
- [x] I have added appropriate labels to this PR (or mentioned needed labels in the description if lacking permissions).
      我已为此 PR 添加了适当的标签（如无权限或需要的标签不存在，请在描述中说明，管理员将后续处理）。
- [ ] I have requested review from relevant code authors using the "Request review" feature when applicable.
      我已在适当情况下使用"Request review"功能请求相关代码作者进行审查。
- [x] I have updated the repository accordingly (If it’s needed).
      我已相应更新了相关仓库（若适用）。
  - [x] [OpenList-Frontend](https://github.com/OpenListTeam/OpenList-Frontend) #XXXX
  - [ ] [OpenList-Docs](https://github.com/OpenListTeam/OpenList-Docs) #XXXX
