### PR TITLE
fix(share): multipath selector is not joined base path

### DIFF
--- a/src/components/MultiPathInput.tsx
+++ b/src/components/MultiPathInput.tsx
@@ -16,6 +16,7 @@ import {
 import { createSignal } from "solid-js"
 import { TbPlus, TbFolder } from "solid-icons/tb"
 import { useT } from "~/hooks"
+import { pathJoin } from "~/utils"
 import { EnhancedFolderTree } from "~/components/EnhancedFolderTree"
 
 export interface MultiPathInputProps {
@@ -25,6 +26,7 @@ export interface MultiPathInputProps {
   readOnly?: boolean
   id?: string
   placeholder?: string
+  basePath?: string
 }
 
 export const MultiPathInput = (props: MultiPathInputProps) => {
@@ -34,7 +36,11 @@ export const MultiPathInput = (props: MultiPathInputProps) => {
 
   const addPath = () => {
     const currentPaths = props.value ? props.value.split("\n") : []
-    const newPaths = [...currentPaths, selectedPath()].filter(Boolean)
+    let sp = selectedPath()
+    if (props.basePath) {
+      sp = pathJoin(props.basePath, sp)
+    }
+    const newPaths = [...currentPaths, sp].filter(Boolean)
     const uniquePaths = [...new Set(newPaths)]
     props.onChange(uniquePaths.join("\n"))
     onClose()

--- a/src/pages/manage/shares/AddOrEdit.tsx
+++ b/src/pages/manage/shares/AddOrEdit.tsx
@@ -7,6 +7,7 @@ import { MaybeLoading } from "~/components"
 import { ResponsiveGrid } from "../common/ResponsiveGrid"
 import { batch, createSignal, Show } from "solid-js"
 import { Item } from "./Item"
+import { me } from "~/store"
 
 const AddOrEdit = () => {
   const t = useT()
@@ -52,6 +53,7 @@ const AddOrEdit = () => {
           type={Type.MultiPath}
           value={files()}
           valid={filesValid()}
+          basePath={me().base_path}
           required
           onChange={(f) => {
             setFiles(f)

--- a/src/pages/manage/shares/Item.tsx
+++ b/src/pages/manage/shares/Item.tsx
@@ -50,6 +50,7 @@ export type ItemProps = {
       type: Type.MultiPath
       onChange?: (value: string) => void
       value: string
+      basePath?: string
     }
   | {
       type: Type.Select
@@ -164,6 +165,7 @@ const Item = (props: ItemProps) => {
             value={props.value as string}
             valid={props.valid}
             readOnly={props.readonly}
+            basePath={props.basePath}
             onChange={(value) => {
               if (props.type === Type.MultiPath) {
                 props.onChange?.(value)

--- a/src/pages/manage/shares/Share.tsx
+++ b/src/pages/manage/shares/Share.tsx
@@ -2,7 +2,6 @@ import { PEmptyResp, ShareInfo, UserMethods } from "~/types"
 import { useFetch, useRouter, useT, useUtil } from "~/hooks"
 import { Badge, Button, HStack, Td, Tr } from "@hope-ui/solid"
 import {
-  base_path,
   handleResp,
   handleRespWithNotifySuccess,
   makeTemplateData,
@@ -29,9 +28,7 @@ function ShareOp(props: ShareProps) {
   const [enableOrDisableLoading, enableOrDisable] = useFetch(
     (): PEmptyResp =>
       r.post(
-        `/share/${props.share.disabled ? "enable" : "disable"}?id=${
-          props.share.id
-        }`,
+        `/share/${props.share.disabled ? "enable" : "disable"}?id=${props.share.id}`,
       ),
   )
   return (


### PR DESCRIPTION
## Description / 描述

使分享页面的路径选择器拼接用户基础目录

## Motivation and Context / 背景

Closes OpenListTeam/OpenList#1429

## How Has This Been Tested? / 测试

## Checklist / 检查清单

- [x] I have read the [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md) document.
      我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md) 文档。
- [x] I have formatted my code with `go fmt` or [prettier](https://prettier.io/).
      我已使用 `go fmt` 或 [prettier](https://prettier.io/) 格式化提交的代码。
- [x] I have added appropriate labels to this PR (or mentioned needed labels in the description if lacking permissions).
      我已为此 PR 添加了适当的标签（如无权限或需要的标签不存在，请在描述中说明，管理员将后续处理）。
- [ ] I have requested review from relevant code authors using the "Request review" feature when applicable.
      我已在适当情况下使用"Request review"功能请求相关代码作者进行审查。
- [x] I have updated the repository accordingly (If it’s needed).
      我已相应更新了相关仓库（若适用）。
  - [x] [OpenList-Frontend](https://github.com/OpenListTeam/OpenList-Frontend) #XXXX
  - [ ] [OpenList-Docs](https://github.com/OpenListTeam/OpenList-Docs) #XXXX
