### PR TITLE
fix(driver/OneDrive): fix direct upload, show size and upload speed

### DIFF
--- a/src/pages/home/uploads/Upload.tsx
+++ b/src/pages/home/uploads/Upload.tsx
@@ -49,11 +49,14 @@ const UploadFile = (props: UploadFileProps) => {
       >
         {props.path}
       </Text>
-      <HStack spacing="$2">
-        <Badge colorScheme={StatusBadge[props.status]}>
-          {t(`home.upload.${props.status}`)}
-        </Badge>
-        <Text>{getFileSize(props.speed)}/s</Text>
+      <HStack spacing="$2" w="$full" justifyContent="space-between">
+        <HStack spacing="$2">
+          <Badge colorScheme={StatusBadge[props.status]}>
+            {t(`home.upload.${props.status}`)}
+          </Badge>
+          <Text>{getFileSize(props.speed)}/s</Text>
+        </HStack>
+        <Text color="$neutral11">{getFileSize(props.size)}</Text>
       </HStack>
       <Progress
         w="$full"


### PR DESCRIPTION
- 修复4-5MB文件直连上传400错误（移除file.size判断，确保Content-Range头设置）
- 添加上传文件大小显示（右对齐灰色文本）
- 实现上传速度实时计算（每500ms更新，使用闭包优化）

修复问题:
- [OpenListTeam/OpenList-Frontend#279](https://github.com/OpenListTeam/OpenList-Frontend/pull/279)
- [https://github.com/OpenListTeam/OpenList/pull/1532](https://github.com/OpenListTeam/OpenList/pull/1532)
