### PR TITLE
feat(local-settings): show_gallery_thumbnails

### DIFF
--- a/src/lang/en/home.json
+++ b/src/lang/en/home.json
@@ -164,6 +164,11 @@
       "direct": "Direct",
       "dblclick": "Double click",
       "disable_while_checked": "Disable while checked"
+    },
+    "show_gallery_thumbnails": "Show gallery thumbnails",
+    "show_gallery_thumbnails_options": {
+      "none": "None",
+      "visible": "Visible"
     }
   },
   "package_download": {

--- a/src/pages/home/folder/Folder.tsx
+++ b/src/pages/home/folder/Folder.tsx
@@ -11,7 +11,7 @@ import { layout } from "~/store"
 import { ContextMenu } from "./context-menu"
 import { Pager } from "./Pager"
 import { useLink, useT } from "~/hooks"
-import { objStore } from "~/store"
+import { objStore, local } from "~/store"
 import { ObjType } from "~/types"
 import { bus } from "~/utils"
 import lightGallery from "lightgallery"
@@ -39,7 +39,7 @@ const Folder = () => {
     dynamicGallery = lightGallery(document.createElement("div"), {
       addClass: "lightgallery-container",
       dynamic: true,
-      thumbnail: true,
+      thumbnail: local["show_gallery_thumbnails"] === "visible",
       plugins: [lgZoom, lgThumbnail, lgRotate, lgAutoplay, lgFullscreen],
       dynamicEl: images().map((obj) => {
         const raw = rawLink(obj, true)
@@ -52,7 +52,7 @@ const Folder = () => {
     })
   }
   createEffect(
-    on(images, () => {
+    on([images, () => local["show_gallery_thumbnails"]], () => {
       dynamicGallery?.destroy()
       dynamicGallery = undefined
     }),

--- a/src/store/local_settings.ts
+++ b/src/store/local_settings.ts
@@ -71,6 +71,12 @@ export const initialLocalSettings = [
     default: "14",
     type: "number",
   },
+  {
+    key: "show_gallery_thumbnails",
+    default: "visible",
+    type: "select",
+    options: ["none", "visible"],
+  },
 ]
 export type LocalSetting = (typeof initialLocalSettings)[number]
 for (const setting of initialLocalSettings) {


### PR DESCRIPTION
<!--
  Provide a general summary of your changes in the Title above.
  The PR title must start with `feat(): `, `docs(): `, `fix(): `, `style(): `, or `refactor(): `, `chore(): `. For example: `feat(component): add new feature`.
  If it spans multiple components, use the main component as the prefix and enumerate in the title, describe in the body.
-->
<!--
  在上方标题中提供您更改的总体摘要。
  PR 标题需以 `feat(): `, `docs(): `, `fix(): `, `style(): `, `refactor(): `, `chore(): ` 其中之一开头，例如：`feat(component): 新增功能`。
  如果跨多个组件，请使用主要组件作为前缀，并在标题中枚举、描述中说明。
-->

## Description / 描述

<!-- Describe your changes in detail -->
<!-- 详细描述您的更改 -->

Added the 'Show gallery thumbnails' feature in' Local Settings', which is enabled by default (previously mandatory) and can be manually selected to 'Visible' or 'None'“

在 ”本地设置“ 添加了 ”显示画廊缩略图“ 功能，默认开启（之前是强制开启），可手动选择 ”显示“ 或者 ”隐藏“

## Motivation and Context / 背景

<!-- Why is this change required? What problem does it solve? -->
<!-- 为什么需要此更改？它解决了什么问题？ -->

When the thumbnail feature is not enabled in storage, browsing large images over approximately 20MiB becomes extremely laggy. Disabling thumbnails makes the browsing smooth.

在存储没有开启缩略图功能时，浏览约 20MiB 以上的大图非常卡顿，如果关闭缩略图就会变得流畅。

<!-- If it fixes an open issue, please link to the issue here. -->
<!-- 如果修复了一个打开的issue，请在此处链接到该issue -->

<!-- Closes #XXXX -->

<!-- or -->
<!-- 或者 -->

<!-- Relates to #XXXX -->

## How Has This Been Tested? / 测试

<!-- Please describe in detail how you tested your changes. -->
<!-- 请详细描述您如何测试更改 -->

Local testing
1. Click on "Local Settings," and at the bottom, you'll find "Show gallery thumbnails" set to "Visible" by default. Turn off "Local Settings," open the image, and thumbnails are indeed displayed.
2. Click on Local Settings again, select "None" for "Show gallery thumbnails," then close Local Settings, open the image, and confirm that the thumbnails are hidden.
3. Repeatedly display and hide to view the image, which meets expectations.

本地测试
1. 点击本地设置，底部有 “显示画廊缩略图” 默认为 “显示”，关闭本地设置，打开图片，确实显示了缩略图。
2. 再次点击本地设置，“显示画廊缩略图” 选择 ”隐藏“，关闭本地设置，打开图片，确实隐藏了缩略图。
3. 反复显示和隐藏，查看图片，符合预期。

## Checklist / 检查清单

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- 检查以下所有要点，并在所有适用的框中打`x` -->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- 如果您对其中任何一项不确定，请不要犹豫提问。我们会帮助您！ -->

- [x] I have read the [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md) document.
      我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md) 文档。
- [x] I have formatted my code with `go fmt` or [prettier](https://prettier.io/).
      我已使用 `go fmt` 或 [prettier](https://prettier.io/) 格式化提交的代码。
- [ ] I have added appropriate labels to this PR (or mentioned needed labels in the description if lacking permissions).
      我已为此 PR 添加了适当的标签（如无权限或需要的标签不存在，请在描述中说明，管理员将后续处理）。
- [ ] I have requested review from relevant code authors using the "Request review" feature when applicable.
      我已在适当情况下使用"Request review"功能请求相关代码作者进行审查。
- [ ] I have updated the repository accordingly (If it’s needed).
      我已相应更新了相关仓库（若适用）。
  - [ ] [OpenList-Frontend](https://github.com/OpenListTeam/OpenList-Frontend) #XXXX
  - [ ] [OpenList-Docs](https://github.com/OpenListTeam/OpenList-Docs) #XXXX
