### PR TITLE
fix(upload): resolve 100-entry limit of readEntries in Chrome

### DIFF
--- a/src/pages/home/uploads/util.ts
+++ b/src/pages/home/uploads/util.ts
@@ -10,7 +10,7 @@ export const traverseFileTree = async (entry: FileSystemEntry) => {
         reject(e)
       }
       if (entry.isFile) {
-        ; (entry as FileSystemFileEntry).file((file) => {
+        ;(entry as FileSystemFileEntry).file((file) => {
           const newFile = new File([file], path + file.name, {
             type: file.type,
           })
@@ -41,12 +41,11 @@ export const traverseFileTree = async (entry: FileSystemEntry) => {
             To actually get all the files, we'll need to call readEntries repeatedly (for each directory we encounter) 
             until it returns an empty array. If we don't, we will miss some files/sub-directories in a directory 
             e.g. in Chrome, readEntries will only return at most 100 entries at a time.
-            */
-            /*if (entries.length > 0) {
-            /*  readEntries()
+            
+            if (entries.length > 0) {
+              readEntries()
             }
             */
-
           }, errorCallback)
         }
         readEntries()


### PR DESCRIPTION
<!--
  Provide a general summary of your changes in the Title above.
  The PR title must start with `feat(): `, `docs(): `, `fix(): `, `style(): `, or `refactor(): `, `chore(): `. For example: `feat(component): add new feature`.
  If it spans multiple components, use the main component as the prefix and enumerate in the title, describe in the body.
-->
<!--
  在上方标题中提供您更改的总体摘要。
  PR 标题需以 `feat(): `, `docs(): `, `fix(): `, `style(): `, `refactor(): `, `chore(): ` 其中之一开头，例如：`feat(component): 新增功能`。
  如果跨多个组件，请使用主要组件作为前缀，并在标题中枚举、描述中说明。
-->

## Description / 描述
This PR implements a recursive loop for dirReader.readEntries() within the traverseFileTree function in the file src/papges/home/uploads/utils.ts. This ensures that all entries in a directory are retrieved, not just the first batch.

<!-- Describe your changes in detail -->
<!-- 详细描述您的更改 -->

## Motivation and Context / 背景

In Chromium-based browsers (Chrome, Edge), the FileSystemDirectoryReader.readEntries() API typically returns a maximum of 100 entries per call. Previously, uploading a folder with more than 100 files would result in only the first 100 files being processed, causing data loss. This change calls readEntries repeatedly until an empty array is returned, ensuring complete folder traversal regardless of the file count.
<!-- Why is this change required? What problem does it solve? -->
<!-- 为什么需要此更改？它解决了什么问题？ -->

<!-- If it fixes an open issue, please link to the issue here. -->
<!-- 如果修复了一个打开的issue，请在此处链接到该issue -->



<!-- or -->
<!-- 或者 -->



## How Has This Been Tested? / 测试

<!-- Please describe in detail how you tested your changes. -->
<!-- 请详细描述您如何测试更改 -->
1. Create a folder containing 512 empty text file.
2. Dragged and dropped the folder into the upload area.
3. Verified that the console/UI correctly identified all 512 files, whereas previously it stopped at 100 around.

## Checklist / 检查清单

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- 检查以下所有要点，并在所有适用的框中打`x` -->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- 如果您对其中任何一项不确定，请不要犹豫提问。我们会帮助您！ -->

- [x] I have read the [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md) document.
      我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md) 文档。
- [x] I have formatted my code with `go fmt` or [prettier](https://prettier.io/).
      我已使用 `go fmt` 或 [prettier](https://prettier.io/) 格式化提交的代码。
- [x] I have added appropriate labels to this PR (or mentioned needed labels in the description if lacking permissions).
      我已为此 PR 添加了适当的标签（如无权限或需要的标签不存在，请在描述中说明，管理员将后续处理）。
- [ ] I have requested review from relevant code authors using the "Request review" feature when applicable.
      我已在适当情况下使用"Request review"功能请求相关代码作者进行审查。
- [ ] I have updated the repository accordingly (If it’s needed).
      我已相应更新了相关仓库（若适用）。
  - [ ] [OpenList-Frontend](https://github.com/OpenListTeam/OpenList-Frontend) #XXXX
  - [ ] [OpenList-Docs](https://github.com/OpenListTeam/OpenList-Docs) #XXXX
