### PR TITLE
fix: use objStore.raw_url for current audio in share links

### DIFF
--- a/src/pages/home/previews/audio.tsx
+++ b/src/pages/home/previews/audio.tsx
@@ -45,7 +45,10 @@ const Preview = () => {
     const audio = {
       name: obj.name,
       artist: "Unknown",
-      url: rawLink(obj, true),
+      // Use objStore.raw_url for current file (has correct auth tokens from backend)
+      // Use rawLink for other files in playlist
+      url:
+        obj.name === objStore.obj.name ? objStore.raw_url : rawLink(obj, true),
       cover: cover,
       lrc: lrc,
     }


### PR DESCRIPTION
## Problem
Audio files couldn't play from share links (`/@s/share_id`) returning HTTP 500 errors.

## Root Cause
The audio preview component used `rawLink(obj, true)` to construct the audio URL:

```tsx
url: rawLink(obj, true),
```

However, `rawLink()` generates URLs by concatenating paths on the frontend, which may lack proper authentication tokens or have incorrect path structure for share links.

**Comparison with other preview components:**
- ✅ Video preview: uses `objStore.raw_url` (line 55 in video.tsx)
- ✅ Image preview: uses `objStore.raw_url` (line 60 in image.tsx)
- ✅ Doc preview: uses `objStore.raw_url` (line 83 in doc.tsx)
- ❌ Audio preview: was using `rawLink(obj, true)` ← **This was the bug**

`objStore.raw_url` is the complete download URL returned by the backend API with proper authentication already applied.

## Solution
For the currently selected audio file, use `objStore.raw_url` (backend-provided URL with correct auth).
For other files in the playlist, continue using `rawLink()` as before.

```tsx
url: obj.name === objStore.obj.name ? objStore.raw_url : rawLink(obj, true),
```

This aligns the audio preview behavior with other preview components.

## Changes
- `src/pages/home/previews/audio.tsx`: Use `objStore.raw_url` for current audio file

## Testing
- Audio files in share links should now play correctly
- Playlist functionality remains unchanged (other files still use rawLink)