### PR TITLE
fix(build): add macOS compatibility for sed command

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -123,7 +123,7 @@ fallback_git_tag() {
 # Update package.json version
 update_package_version() {
     if [[ "$BUILD_TYPE" == "dev" ]]; then
-        # Handle both macOS and Linux sed syntax
+        # Handle both BSD and GNU sed syntax
         if [[ "$OSTYPE" == "darwin"* ]]; then
             sed -i "" "s/\"version\": *\"[^\"]*\"/\"version\": \"${git_version_clean}\"/" package.json
         else


### PR DESCRIPTION
## Description / 描述

Fixed `sed` command syntax in `build.sh` to support both macOS (BSD sed) and Linux/Windows (GNU sed) environments. The script now detects the operating system using `$OSTYPE` and applies the appropriate `sed` syntax when updating `package.json` version during dev builds.

修复了 `build.sh` 中的 `sed` 命令语法，使其同时支持 macOS（BSD sed）和 Linux/Windows（GNU sed）环境。脚本现在通过 `$OSTYPE` 检测操作系统，并在开发构建更新 `package.json` 版本时应用相应的 `sed` 语法。

**Changes / 改动:**
- Added OS detection for macOS (`darwin*`)
- macOS: Uses `sed -i ""` (BSD sed syntax)
- Linux/Windows: Uses `sed -i` (GNU sed syntax)

## Motivation and Context / 背景

The original `sed -i` command without an empty string argument works on Linux/Windows but fails on macOS because macOS uses BSD sed, which requires either `sed -i ""` or `sed -i .bak`.

原始的 `sed -i` 命令在 Linux/Windows 上可以正常工作，但在 macOS 上会失败，因为 macOS 使用 BSD sed，需要使用 `sed -i ""` 或 `sed -i .bak` 语法。

This caused build failures for developers working on macOS when running dev builds.

这导致在 macOS 上工作的开发者运行开发构建时出现失败。

## How Has This Been Tested? / 测试

- ✅ Tested on macOS (darwin) - `sed -i ""` syntax works correctly
- ✅ Verified code logic for Linux (`linux-gnu`) - uses `sed -i`
- ✅ Verified code logic for Windows Git Bash (`msys`) - uses `sed -i`
- ✅ Verified code logic for Windows WSL (`linux-gnu`) - uses `sed -i`

在 macOS 上测试通过，并验证了 Linux 和 Windows 环境的代码逻辑。

## Checklist / 检查清单

- [x] I have read the [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md) document.
      我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md) 文档。
- [x] I have formatted my code with `go fmt` or [prettier](https://prettier.io/).
      我已使用 `go fmt` 或 [prettier](https://prettier.io/) 格式化提交的代码。
- [ ] I have added appropriate labels to this PR (or mentioned needed labels in the description if lacking permissions).
      我已为此 PR 添加了适当的标签（如无权限或需要的标签不存在，请在描述中说明，管理员将后续处理）。
      
      **Suggested labels / 建议标签:** `bug`, `build`
      
- [ ] I have requested review from relevant code authors using the "Request review" feature when applicable.
      我已在适当情况下使用"Request review"功能请求相关代码作者进行审查。
- [x] I have updated the repository accordingly (If it's needed).
      我已相应更新了相关仓库（若适用）。
  - [x] [OpenList-Frontend](https://github.com/OpenListTeam/OpenList-Frontend) - This PR
  - [ ] [OpenList-Docs](https://github.com/OpenListTeam/OpenList-Docs) - Not needed
