### PR TITLE
feat(sharing): add custom share ID input and permission

### DIFF
--- a/src/lang/en/shares.json
+++ b/src/lang/en/shares.json
@@ -1,6 +1,7 @@
 {
   "expires": "Expiration time",
   "id": "ID",
+  "id_placeholder": "Custom ID (optional, leave empty for random)",
   "accessed": "Access count",
   "max_accessed": "Maximum access count",
   "pwd": "Share code",

--- a/src/lang/en/users.json
+++ b/src/lang/en/users.json
@@ -14,7 +14,8 @@
     "ftp_manage": "FTP manage",
     "read_archives": "Read archives",
     "decompress": "Decompress",
-    "share": "Share"
+    "share": "Share",
+    "customize_share_id": "Customize share ID"
   },
   "username": "Username",
   "password": "Password",

--- a/src/pages/home/toolbar/Share.tsx
+++ b/src/pages/home/toolbar/Share.tsx
@@ -123,6 +123,16 @@ export const Share = () => {
           <Match when={link() === ""}>
             <ModalBody>
               <VStack spacing="$1" alignItems="flex-start">
+                <Text size="sm">{t("shares.id")}</Text>
+                <Input
+                  size="sm"
+                  value={share.id ?? ""}
+                  maxLength={64}
+                  placeholder={t("shares.id_placeholder")}
+                  onInput={(e) => {
+                    setShare("id", e.currentTarget.value)
+                  }}
+                />
                 <Text size="sm">{t("shares.remark")}</Text>
                 <Textarea
                   size="sm"

--- a/src/pages/manage/shares/AddOrEdit.tsx
+++ b/src/pages/manage/shares/AddOrEdit.tsx
@@ -45,9 +45,20 @@ const AddOrEdit = () => {
     <MaybeLoading loading={id ? shareLoading() : false}>
       <Heading mb="$2">{t(`global.${id ? "edit" : "add"}`)}</Heading>
       <ResponsiveGrid>
-        <Show when={id}>
-          <Item name="id" type={Type.String} value={id} valid readonly={true} />
-        </Show>
+        <Item
+          name="id"
+          type={Type.String}
+          value={id ? ((share as ShareUpdate).new_id ?? id) : (share.id ?? "")}
+          valid
+          placeholder={id ? id : t("shares.id_placeholder")}
+          onChange={(v) => {
+            if (id) {
+              setShare({ ...share, new_id: v } as any)
+            } else {
+              setShare({ ...share, id: v } as any)
+            }
+          }}
+        />
         <Item
           name="files"
           type={Type.MultiPath}

--- a/src/types/share.ts
+++ b/src/types/share.ts
@@ -1,6 +1,7 @@
 import { ExtractFolder, OrderBy, OrderDirection } from "~/types/storage"
 
 export interface Share {
+  id?: string
   expires: string | null
   pwd: string
   max_accessed: number
@@ -16,6 +17,7 @@ export interface Share {
 
 export interface ShareUpdate extends Share {
   id: string
+  new_id: string
   accessed: number
 }
 

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -33,6 +33,7 @@ export const UserPermissions = [
   "read_archives",
   "decompress",
   "share",
+  "customize_share_id",
 ] as const
 
 export const UserMethods = {


### PR DESCRIPTION
## Description / 描述
                                                                                       
  Frontend changes for custom share ID support (backend PR:                            
  OpenListTeam/OpenList#XXXX).
                                                                                       
  - Add ID input field in manage share create/edit form (`AddOrEdit.tsx`)              
  - Add ID input in quick share dialog (`Share.tsx`) with `maxLength=64`
  - Add `new_id` field to `ShareUpdate` type for renaming share IDs                    
  - Add optional `id` field to `Share` type for custom ID on creation                  
  - Add `customize_share_id` permission (bit 15) to `UserPermissions`                  
  - Add i18n strings for ID placeholder and permission label                           
                                                                                       
  ## Motivation and Context / 背景
                                                                                       
  Random share IDs are hard to remember. This enables users with the                   
  `customize_share_id` permission to set memorable custom IDs (e.g. `my-photos`) when
  creating or editing shares.                                                          
                  
  Relates to OpenListTeam/OpenList#1806

  ## How Has This Been Tested? / 测试                                                  
                                                 
  - Verified ID input renders in both manage share form and quick share dialog
  - Verified `customize_share_id` permission checkbox renders in user management page  
                                                                                       
  ## Checklist / 检查清单                                                              
                                                                                       
  - [x] I have read the                                                                
  [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md)
  document.                                                                            
  - [x] I have formatted my code with `go fmt` or [prettier](https://prettier.io/).
  - [ ] I have added appropriate labels to this PR (or mentioned needed labels in the
  description if lacking permissions).                                                 
        Labels needed: `enhancement`
  - [ ] I have requested review from relevant code authors using the "Request review"  
  feature when applicable.
  - [x] I have updated the repository accordingly (If it's needed).
    - [x] [OpenList-Frontend](https://github.com/OpenListTeam/OpenList-Frontend) (this 
  PR)
    - [ ] [OpenList-Docs](https://github.com/OpenListTeam/OpenList-Docs)