### PR TITLE
  feat(tasks): prioritize running undone tasks by default

### DIFF
--- a/src/pages/manage/tasks/Tasks.tsx
+++ b/src/pages/manage/tasks/Tasks.tsx
@@ -55,6 +55,16 @@ export interface TaskLocalSetter {
 
 export type TaskAttribute = TaskInfo & TaskViewAttribute & TaskLocalContainer
 
+const undoneStatePriority: Record<number, number> = {
+  1: 0,
+  0: 1,
+  8: 1,
+  9: 1,
+  3: 2,
+  5: 2,
+  6: 2,
+}
+
 export const Tasks = (props: TasksProps) => {
   const t = useT()
   const [loading, get] = useFetch(
@@ -85,8 +95,17 @@ export const Tasks = (props: TasksProps) => {
           : -1,
   }
   const curSorter = createMemo(() => {
-    return (a: TaskInfo, b: TaskInfo) =>
-      (orderReverse() ? -1 : 1) * sorter[orderBy()](a, b)
+    return (a: TaskInfo, b: TaskInfo) => {
+      if (props.done === "undone" && orderBy() === "name" && !orderReverse()) {
+        const priorityDelta =
+          (undoneStatePriority[a.state] ?? 3) -
+          (undoneStatePriority[b.state] ?? 3)
+        if (priorityDelta !== 0) {
+          return priorityDelta
+        }
+      }
+      return (orderReverse() ? -1 : 1) * sorter[orderBy()](a, b)
+    }
   })
   const refresh = async () => {
     const resp = await get()


### PR DESCRIPTION
## Description / 描述

  在未完成任务列表中，按任务状态优先级排序：正在运行的任务（state=1）排在最前，其次是等待中/排队中的任务（state=0,8,9），最后是已取消/出错等其他状态（state=3,5,6）。仅在 `undone` 视图、按名称排序且未反转时生效。
## Motivation and Context / 背景

此更改让运行中的任务自动置顶，提升任务管理效率。
 
## How Has This Been Tested? / 测试

  - running 状态任务排在最前
  - 点击名称列之后按名称排序
  - 验证 `done` 视图不受影响

## Checklist / 检查清单

  - [x] I have read the [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md) document.
  - [x] I have formatted my code with `go fmt` or [prettier](https://prettier.io/).
  - [x] I have added appropriate labels to this PR (or mentioned needed labels in the description if lacking
  permissions).
  - [x] I have requested review from relevant code authors using the "Request review" feature when applicable.
  - [x] I have updated the repository accordingly (If it's needed).