### PR TITLE
feat(task): show offline download file info

### DIFF
--- a/src/lang/en/tasks.json
+++ b/src/lang/en/tasks.json
@@ -47,6 +47,8 @@
     },
     "offline_download": {
       "url": "URL",
+      "file_name": "File Name",
+      "file_size": "File Size",
       "path": "Destination Path",
       "transfer_src": "Source Path",
       "transfer_src_local": "Source Path (Local)",

--- a/src/pages/manage/tasks/Task.tsx
+++ b/src/pages/manage/tasks/Task.tsx
@@ -18,7 +18,7 @@ import {
 import { createSignal, For, Show } from "solid-js"
 import { useT, useFetch } from "~/hooks"
 import { PEmptyResp } from "~/types"
-import { handleResp, notify, r } from "~/utils"
+import { getFileSize, handleResp, notify, r } from "~/utils"
 import { TaskAttribute, TaskLocalSetter, TasksProps } from "./Tasks"
 import { me } from "~/store"
 
@@ -134,6 +134,9 @@ export const Task = (props: TaskAttribute & TasksProps & TaskLocalSetter) => {
   )
   const title =
     matches === null ? props.name : props.nameAnalyzer.title(matches)
+  const showFileInfo = () =>
+    props.type === "offline_download" && props.done === "undone"
+  const fileSize = () => props.file_size || props.total_bytes
   const startTime =
     props.start_time === null ? -1 : new Date(props.start_time).getTime()
   const endTime =
@@ -320,6 +323,26 @@ export const Task = (props: TaskAttribute & TasksProps & TaskLocalSetter) => {
                   )
                 }}
               </For>
+            </Show>
+            <Show when={showFileInfo() && props.file_name}>
+              <GridItem
+                color="$neutral9"
+                textAlign="right"
+                css={{ whiteSpace: "nowrap" }}
+              >
+                {t(`tasks.attr.offline_download.file_name`)}
+              </GridItem>
+              <GridItem color="$neutral9">{props.file_name}</GridItem>
+            </Show>
+            <Show when={showFileInfo() && fileSize() > 0}>
+              <GridItem
+                color="$neutral9"
+                textAlign="right"
+                css={{ whiteSpace: "nowrap" }}
+              >
+                {t(`tasks.attr.offline_download.file_size`)}
+              </GridItem>
+              <GridItem color="$neutral9">{getFileSize(fileSize())}</GridItem>
             </Show>
             <GridItem
               color="$neutral9"

--- a/src/pages/manage/tasks/Task.tsx
+++ b/src/pages/manage/tasks/Task.tsx
@@ -134,8 +134,7 @@ export const Task = (props: TaskAttribute & TasksProps & TaskLocalSetter) => {
   )
   const title =
     matches === null ? props.name : props.nameAnalyzer.title(matches)
-  const showFileInfo = () =>
-    props.type === "offline_download" && props.done === "undone"
+  const showFileInfo = () => props.type === "offline_download"
   const fileSize = () => props.file_size || props.total_bytes
   const startTime =
     props.start_time === null ? -1 : new Date(props.start_time).getTime()

--- a/src/types/task.ts
+++ b/src/types/task.ts
@@ -9,5 +9,7 @@ export interface TaskInfo {
   start_time: string | null
   end_time: string | null
   total_bytes: number
+  file_name?: string
+  file_size?: number
   error: string
 }


### PR DESCRIPTION
## Summary / 摘要

- Show file name and file size in the expanded view of running offline download tasks.
- Add optional `file_name` and `file_size` fields to the frontend task response type.
- Add task attribute labels for the new offline download file info rows.

- [ ] This PR has breaking changes.
      / 此 PR 包含破坏性变更。
- [ ] This PR changes public API, config, storage format, or migration behavior.
      / 此 PR 修改了公开 API、配置、存储格式或迁移行为。
- [x] This PR requires corresponding changes in related repositories.
      / 此 PR 需要关联仓库同步修改。

Related repository PRs / 关联仓库 PR:

- OpenList: https://github.com/OpenListTeam/OpenList/pull/2581
- OpenList-Docs: N/A

## Testing / 测试

- [ ] `go test ./...`
- [x] `pnpm exec prettier --write src/types/task.ts src/pages/manage/tasks/Task.tsx src/lang/en/tasks.json`
- [ ] `pnpm lint`: currently blocked by existing TypeScript errors in `src/pages/home/previews/archive.tsx` and `src/pages/manage/storages/AddOrEdit.tsx`.
- [ ] Manual test / 手动测试: not run locally; depends on the related backend API fields.

## Checklist / 检查清单

- [x] I have read [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md).
      / 我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md)。
- [x] I confirm this contribution follows the repository license, contribution policy, and code of conduct.
      / 我确认此贡献符合仓库许可证、贡献规范和行为准则。
- [x] I have formatted the changed code with `gofmt`, `go fmt`, or `prettier` where applicable.
      / 我已按适用情况使用 `gofmt`、`go fmt` 或 `prettier` 格式化变更代码。
- [ ] I have requested review from relevant maintainers or code owners where applicable.
      / 我已在适用情况下请求相关维护者或代码所有者审查。

## AI Disclosure / AI 使用声明

- [x] This PR includes AI-assisted content.
      / 此 PR 包含 AI 辅助内容。

Tools used / 使用工具:

- [ ] ChatGPT
- [x] Codex
- [ ] GitHub Copilot
- [ ] Claude
- [ ] Gemini
- [ ] Other (please specify) / 其他（请注明）:

Usage scope / 使用范围:

- [x] Code generation / 代码生成
- [ ] Refactoring / 重构
- [ ] Documentation / 文档
- [ ] Tests / 测试
- [x] Translation / 翻译
- [x] Review assistance / 审查辅助

- [x] I have reviewed and validated all AI-assisted content included in this PR.
      / 我已审核并验证此 PR 中的所有 AI 辅助内容。
- [x] I have ensured that all AI-assisted commits include `Co-Authored-By` attribution.
      / 我已确保所有 AI 辅助提交都包含 `Co-Authored-By` 归属信息。
- [ ] I can reproduce all AI-assisted content included in this PR without any AI tools.
      / 我可以在没有任何 AI 工具的情况下重现此 PR 中包含的所有 AI 辅助内容。
