### PR TITLE
fix(markdown): only highlight code blocks with explicit language class

### DIFF
--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -273,7 +273,12 @@ export function Markdown(props: {
 
       setTimeout(() => {
         setShow(true)
-        // Only highlight code blocks with an explicit language (not plain/auto-detect)
+        // Only highlight code blocks with an explicit, supported language
+        const noHighlight = new Set([
+          "language-plain",
+          "language-plaintext",
+          "language-text",
+        ])
         markdownRef()
           ?.querySelectorAll('pre code[class*="language-"]')
           ?.forEach((el) => {
@@ -281,7 +286,11 @@ export function Markdown(props: {
             const langClass = Array.from(classList).find((c) =>
               c.startsWith("language-"),
             )
-            if (langClass && langClass !== "language-plain") {
+            if (
+              langClass &&
+              !noHighlight.has(langClass) &&
+              hljs.getLanguage(langClass.replace("language-", ""))
+            ) {
               hljs.highlightElement(el as HTMLElement)
             }
           })

--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -273,7 +273,18 @@ export function Markdown(props: {
 
       setTimeout(() => {
         setShow(true)
-        hljs.highlightAll()
+        // Only highlight code blocks with an explicit language (not plain/auto-detect)
+        markdownRef()
+          ?.querySelectorAll('pre code[class*="language-"]')
+          ?.forEach((el) => {
+            const classList = (el as HTMLElement).classList
+            const langClass = Array.from(classList).find((c) =>
+              c.startsWith("language-"),
+            )
+            if (langClass && langClass !== "language-plain") {
+              hljs.highlightElement(el as HTMLElement)
+            }
+          })
         if (hasMermaid && window.mermaid) {
           window.mermaid.initialize({
             startOnLoad: false,


### PR DESCRIPTION
<!--
PR title / PR 标题:
- Use Conventional Commits: `type(scope): summary`
- Allowed types: `feat`, `docs`, `fix`, `style`, `refactor`, `chore`
- Scope is required by the current PR title check.
- For breaking changes, add `!`: `feat(driver)!: change auth flow`
-->

## Summary / 摘要

`hljs.highlightAll()` applies auto-detection to all `<pre><code>` blocks,
including those without a `language-*` class from code fences with no
language specified. This causes random highlighting on plain text blocks.

Replaced with selective `highlightElement()` — only target code blocks
that have an explicit `language-*` class, skip `language-plain`.

<!--
- List user-visible behavior changes.
- List important implementation changes.
- Mention config, storage, API, or compatibility changes if any.

- 列出用户可感知的行为变化。
- 列出重要实现变化。
- 如涉及配置、存储、API 或兼容性变化，请明确说明。
-->

- [ ] This PR has breaking changes.
      / 此 PR 包含破坏性变更。
- [ ] This PR changes public API, config, storage format, or migration behavior.
      / 此 PR 修改了公开 API、配置、存储格式或迁移行为。
- [ ] This PR requires corresponding changes in related repositories.
      / 此 PR 需要关联仓库同步修改。

Related repository PRs / 关联仓库 PR:

- OpenList:
- OpenList-Docs:

## Related Issues / 关联 Issue

Closes OpenListTeam/OpenList#2342

<!--
Use `Closes #123`, `Fixes #123`, or `Relates to #123`.
Remove this section if not applicable.
使用 `Closes #123`、`Fixes #123` 或 `Relates to #123`。
不适用时请删除本节。
-->

## Testing / 测试

<!--
Describe commands, platforms, and manual checks.
If not tested, explain why.

说明执行过的命令、测试平台和手动验证。
如果未测试，请说明原因。
-->

- [ ] `go test ./...`
- [x] Manual test / 手动测试: Built and deployed locally with a `/tmp/test`
      directory containing the exact code blocks from the issue
      (SQL Server keys, rarreg.key, VMware keys). Plain code blocks
      no longer show random highlighting.

## Checklist / 检查清单

- [x] I have read [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md).
      / 我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md)。
- [x] I confirm this contribution follows the repository license, contribution policy, and code of conduct.
      / 我确认此贡献符合仓库许可证、贡献规范和行为准则。
- [x] I have formatted the changed code with `prettier` where applicable.
      / 我已按适用情况使用 `prettier` 格式化变更代码。
- [ ] I have requested review from relevant maintainers or code owners where applicable.
      / 我已在适用情况下请求相关维护者或代码所有者审查。

## AI Disclosure / AI 使用声明

<!--
Please disclose any substantial AI assistance used in this PR.
Minor AI assistance, such as typo fixes, autocomplete, formatting suggestions,
or wording polish, does not need to be disclosed.
Remove this section if not applicable.

请披露此 PR 中使用的重要 AI 辅助内容。
轻微 AI 辅助，例如拼写修正、自动补全、格式建议或文字润色，无需披露。
如不适用，请删除本节。

Deliberate non-disclosure may be treated as a trust and compliance issue.

故意隐瞒 AI 使用情况可能被视为信任与合规问题。
-->

- [x] This PR includes AI-assisted content.
      / 此 PR 包含 AI 辅助内容。

Tools used / 使用工具:

- [ ] ChatGPT
- [ ] Codex
- [ ] GitHub Copilot
- [ ] Claude
- [ ] Gemini
- [x] Other (please specify) / 其他（请注明）: DeepSeek

Usage scope / 使用范围:

- [x] Code generation / 代码生成
- [ ] Refactoring / 重构
- [ ] Documentation / 文档
- [ ] Tests / 测试
- [ ] Translation / 翻译
- [ ] Review assistance / 审查辅助

- [x] I have reviewed and validated all AI-assisted content included in this PR.
      / 我已审核并验证此 PR 中的所有 AI 辅助内容。
- [ ] I have ensured that all AI-assisted commits include `Co-Authored-By` attribution.
      / 我已确保所有 AI 辅助提交都包含 `Co-Authored-By` 归属信息。
- [ ] I can reproduce all AI-assisted content included in this PR without any AI tools.
      / 我可以在没有任何 AI 工具的情况下重现此 PR 中包含的所有 AI 辅助内容。