### PR TITLE
feat(drivers/s3): support direct multipart upload

### DIFF
--- a/src/pages/home/uploads/direct.ts
+++ b/src/pages/home/uploads/direct.ts
@@ -57,6 +57,10 @@ export const HttpDirectUpload: Upload = async (
   const uploadURL = uploadInfo.upload_url
   const method = uploadInfo.method || "PUT"
 
+  if (uploadInfo.upload_urls) {
+    return await uploadS3Multipart(file, uploadInfo, setUpload)
+  }
+
   if (chunkSize > 0) {
     // Always use chunked upload when chunkSize is provided
     // This ensures Content-Range header is set for all files
@@ -78,6 +82,144 @@ export const HttpDirectUpload: Upload = async (
       setUpload,
     )
   }
+}
+
+async function uploadS3Multipart(
+  file: File,
+  uploadInfo: {
+    chunk_size: number
+    upload_urls: string[]
+    complete_url: string
+    abort_url: string
+  },
+  setUpload?: SetUpload,
+): Promise<undefined> {
+  const calcSpeed = createSpeedCalculator()
+  const parts: { partNumber: number; etag: string }[] = []
+  let uploadedBytes = 0
+
+  try {
+    for (let i = 0; i < uploadInfo.upload_urls.length; i++) {
+      const start = i * uploadInfo.chunk_size
+      const chunk = file.slice(start, start + uploadInfo.chunk_size)
+      const etag = await uploadS3Part(
+        chunk,
+        uploadInfo.upload_urls[i],
+        i + 1,
+        uploadedBytes,
+        file.size,
+        calcSpeed,
+        setUpload,
+      )
+      parts.push({ partNumber: i + 1, etag })
+      uploadedBytes += chunk.size
+    }
+
+    const body = buildS3CompleteMultipartUploadXML(parts)
+    const response = await fetch(uploadInfo.complete_url, {
+      method: "POST",
+      body,
+    })
+    await validateS3CompleteResponse(response)
+  } catch (error) {
+    // Avoid leaving incomplete multipart uploads billed by the object store.
+    void fetch(uploadInfo.abort_url, { method: "DELETE" })
+    throw error
+  }
+
+  return undefined
+}
+
+function buildS3CompleteMultipartUploadXML(
+  parts: { partNumber: number; etag: string }[],
+): string {
+  const xml = document.implementation.createDocument(
+    "",
+    "CompleteMultipartUpload",
+  )
+  const root = xml.documentElement
+
+  for (const { partNumber, etag } of parts) {
+    const part = xml.createElement("Part")
+    const partNumberNode = xml.createElement("PartNumber")
+    partNumberNode.textContent = String(partNumber)
+    const etagNode = xml.createElement("ETag")
+    etagNode.textContent = etag
+    part.append(partNumberNode, etagNode)
+    root.append(part)
+  }
+
+  return new XMLSerializer().serializeToString(xml)
+}
+
+async function validateS3CompleteResponse(response: Response): Promise<void> {
+  const body = await response.text()
+  if (!response.ok) {
+    throw new Error(
+      `Complete multipart upload failed with status ${response.status}: ${body}`,
+    )
+  }
+
+  const xml = new DOMParser().parseFromString(body, "application/xml")
+  const parseError = xml.querySelector("parsererror")
+  if (parseError) {
+    throw new Error("Complete multipart upload returned invalid XML")
+  }
+
+  const error = xml.querySelector("Error")
+  if (error) {
+    const code = error.querySelector("Code")?.textContent?.trim()
+    const message = error.querySelector("Message")?.textContent?.trim()
+    throw new Error(
+      `Complete multipart upload failed${code ? ` (${code})` : ""}${message ? `: ${message}` : ""}`,
+    )
+  }
+
+  if (!xml.querySelector("CompleteMultipartUploadResult")) {
+    throw new Error("Complete multipart upload returned an unexpected response")
+  }
+}
+
+function uploadS3Part(
+  chunk: Blob,
+  uploadURL: string,
+  partNumber: number,
+  uploadedBytes: number,
+  totalSize: number,
+  calcSpeed: ReturnType<typeof createSpeedCalculator>,
+  setUpload?: SetUpload,
+): Promise<string> {
+  const xhr = new XMLHttpRequest()
+  return new Promise((resolve, reject) => {
+    xhr.upload.addEventListener("progress", (e) => {
+      if (e.lengthComputable && setUpload) {
+        const totalLoaded = uploadedBytes + e.loaded
+        setUpload("progress", (totalLoaded / totalSize) * 100)
+        calcSpeed(totalLoaded, setUpload)
+      }
+    })
+    xhr.addEventListener("load", () => {
+      if (xhr.status < 200 || xhr.status >= 300) {
+        reject(
+          new Error(
+            `Upload part ${partNumber} failed with status ${xhr.status}`,
+          ),
+        )
+        return
+      }
+      const etag = xhr.getResponseHeader("ETag")
+      if (!etag) {
+        reject(new Error(`Upload part ${partNumber} did not return an ETag`))
+        return
+      }
+      resolve(etag)
+    })
+    xhr.addEventListener("error", () =>
+      reject(new Error(`Upload part ${partNumber} failed`)),
+    )
+    xhr.open("PUT", uploadURL)
+    xhr.send(chunk)
+  })
 }
 
 async function uploadSingle(


### PR DESCRIPTION
<!--
PR title / PR 标题:
- Use Conventional Commits: `type(scope): summary`
- Allowed types: `feat`, `docs`, `fix`, `style`, `refactor`, `chore`
- Scope is required by the current PR title check.
- For breaking changes, add `!`: `feat(driver)!: change auth flow`
-->

## Summary / 摘要

<!--
Briefly describe what changed and why.
简要说明改了什么，以及为什么需要改。
-->
There is no user-visible behavior changes for uploading.

HTTP Direct for S3 is now upload by multipart unless DirectUploadMaxParts=1 while the default value is 10000. If S3 is standard, there will be nothing change.
<!--
- List user-visible behavior changes.
- List important implementation changes.
- Mention config, storage, API, or compatibility changes if any.

- 列出用户可感知的行为变化。
- 列出重要实现变化。
- 如涉及配置、存储、API 或兼容性变化，请明确说明。
-->

- [ ] This PR has breaking changes.
      / 此 PR 包含破坏性变更。
- [ ] This PR changes public API, config, storage format, or migration behavior.
      / 此 PR 修改了公开 API、配置、存储格式或迁移行为。
- [x] This PR requires corresponding changes in related repositories.
      / 此 PR 需要关联仓库同步修改。

Related repository PRs / 关联仓库 PR:

- OpenList: https://github.com/OpenListTeam/OpenList/pull/2847
- OpenList-Docs:

## Related Issues / 关联 Issue

<!--
Use `Closes #123`, `Fixes #123`, or `Relates to #123`.
Remove this section if not applicable.
使用 `Closes #123`、`Fixes #123` 或 `Relates to #123`。
不适用时请删除本节。
-->

## Testing / 测试

<!--
Describe commands, platforms, and manual checks.
If not tested, explain why.

说明执行过的命令、测试平台和手动验证。
如果未测试，请说明原因。
-->

- [ ] `go test ./...`
no go test available
- [x] Manual test / 手动测试:
test on Aliyun OSS and it uploads in 50 parts as planned. No larger file tested.

## Checklist / 检查清单

- [x] I have read [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md).
      / 我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md)。
- [x] I confirm this contribution follows the repository license, contribution policy, and code of conduct.
      / 我确认此贡献符合仓库许可证、贡献规范和行为准则。
- [x] I have formatted the changed code with `gofmt`, `go fmt`, or `prettier` where applicable.
      / 我已按适用情况使用 `gofmt`、`go fmt` 或 `prettier` 格式化变更代码。
- [ ] I have requested review from relevant maintainers or code owners where applicable.
      / 我已在适用情况下请求相关维护者或代码所有者审查。
No right to request review.

## AI Disclosure / AI 使用声明

<!--
Please disclose any substantial AI assistance used in this PR.
Minor AI assistance, such as typo fixes, autocomplete, formatting suggestions,
or wording polish, does not need to be disclosed.
Remove this section if not applicable.

请披露此 PR 中使用的重要 AI 辅助内容。
轻微 AI 辅助，例如拼写修正、自动补全、格式建议或文字润色，无需披露。
如不适用，请删除本节。

Deliberate non-disclosure may be treated as a trust and compliance issue.

故意隐瞒 AI 使用情况可能被视为信任与合规问题。
-->

- [x] This PR includes AI-assisted content.
      / 此 PR 包含 AI 辅助内容。

Tools used / 使用工具:

- [ ] ChatGPT
- [ ] Codex
- [ ] GitHub Copilot
- [ ] Claude
- [x] Gemini
- [ ] Other (please specify) / 其他（请注明）:

Usage scope / 使用范围:

- [x] Code generation / 代码生成
- [ ] Refactoring / 重构
- [ ] Documentation / 文档
- [ ] Tests / 测试
- [ ] Translation / 翻译
- [ ] Review assistance / 审查辅助

- [x] I have reviewed and validated all AI-assisted content included in this PR.
      / 我已审核并验证此 PR 中的所有 AI 辅助内容。
- [ ] I have ensured that all AI-assisted commits include `Co-Authored-By` attribution.
      / 我已确保所有 AI 辅助提交都包含 `Co-Authored-By` 归属信息。
- [ ] I can reproduce all AI-assisted content included in this PR without any AI tools.
      / 我可以在没有任何 AI 工具的情况下重现此 PR 中包含的所有 AI 辅助内容。
