### PR TITLE
fix(offline): show destination tools for ED2K downloads

### DIFF
--- a/src/pages/home/toolbar/OfflineDownloadEnhanced.tsx
+++ b/src/pages/home/toolbar/OfflineDownloadEnhanced.tsx
@@ -101,8 +101,9 @@ export const OfflineDownloadEnhanced = () => {
 
   // 下载工具列表
   const [tools, setTools] = createSignal([] as string[])
-  const [toolsLoading, reqTool] = useFetch((): PResp<string[]> => {
-    return r.get("/public/offline_download_tools")
+  const [toolsLoading, reqTool] = useFetch((path: string): PResp<string[]> => {
+    const query = path ? `?path=${encodeURIComponent(path)}` : ""
+    return r.get(`/public/offline_download_tools${query}`)
   })
   const [tool, setTool] = createSignal("")
   const [deletePolicy, setDeletePolicy] = createSignal<DeletePolicy>(
@@ -241,19 +242,22 @@ export const OfflineDownloadEnhanced = () => {
     }
   })
 
-  onMount(async () => {
-    const resp = await reqTool()
+  const loadTools = async (path: string) => {
+    const resp = await reqTool(path)
     handleResp(resp, (data) => {
       setTools(data)
       setTool(data[0])
     })
-  })
+  }
+
+  onMount(() => loadTools(pathname()))
 
   // 监听 bus 事件
   const handler = (name: string) => {
     if (name === "offline_download") {
       const currentPath = pathname()
       setSavePath(currentPath)
+      void loadTools(currentPath)
       onOpen()
     }
   }


### PR DESCRIPTION
## Summary / 摘要

Show the offline-download tools available for the current destination storage.

- Include the current destination path in the offline-download-tools request.
- Refresh the tool list when the dialog opens so a mounted storage can expose its native tool.
- Keep the existing tool selection and submission flow unchanged.

This allows the frontend to display the native 115 tool when the destination is a 115 storage. The corresponding backend change is in [OpenList PR #2920](https://github.com/OpenListTeam/OpenList/pull/2920).

- [ ] This PR has breaking changes.
      / 此 PR 包含破坏性变更。
- [ ] This PR changes public API, config, storage format, or migration behavior.
      / 此 PR 修改了公开 API、配置、存储格式或迁移行为。
- [x] This PR requires corresponding changes in related repositories.
      / 此 PR 需要关联仓库同步修改。

Related repository PRs / 关联仓库 PR:

- OpenList: [#2920](https://github.com/OpenListTeam/OpenList/pull/2920)
- OpenList-Docs: N/A

## Related Issues / 关联 Issue

Relates to #2891

## Testing / 测试

- [x] `pnpm build`
- [x] Prettier check passed.
- [ ] `pnpm lint` — NOT PASS; existing unrelated errors remain in MonacoEditor, archive, and storage form files.
- [ ] Manual test / 手动测试: NOT RUN for this frontend branch.

## Checklist / 检查清单

- [x] I have read [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md).
      / 我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md)。
- [x] I confirm this contribution follows the repository license, contribution policy, and code of conduct.
      / 我确认此贡献符合仓库许可证、贡献规范和行为准则。
- [x] I have formatted the changed code with `gofmt`, `go fmt`, or `prettier` where applicable.
      / 我已按适用情况使用 `gofmt`、`go fmt` 或 `prettier` 格式化变更代码。
- [x] I have requested review from relevant maintainers or code owners where applicable.
      / 我已在适用情况下请求相关维护者或代码所有者审查。

## AI Disclosure / AI 使用声明

- [x] This PR includes AI-assisted content.
      / 此 PR 包含 AI 辅助内容。

Tools used / 使用工具:

- [ ] ChatGPT
- [x] Codex
- [ ] GitHub Copilot
- [ ] Claude
- [ ] Gemini
- [ ] Other (please specify) / 其他（请注明）:

Usage scope / 使用范围:

- [x] Code generation / 代码生成
- [ ] Refactoring / 重构
- [ ] Documentation / 文档
- [ ] Tests / 测试
- [ ] Translation / 翻译
- [x] Review assistance / 审查辅助

- [x] I have reviewed and validated all AI-assisted content included in this PR.
      / 我已审核并验证此 PR 中的所有 AI 辅助内容。
- [x] I have ensured that all AI-assisted commits include `Co-Authored-By` attribution.
      / 我已确保所有 AI 辅助提交都包含 `Co-Authored-By` 归属信息。
- [x] I can reproduce all AI-assisted content included in this PR without any AI tools.
      / 我可以在没有任何 AI 工具的情况下重现此 PR 中包含的所有 AI 辅助内容。
