### PR TITLE
feat(i18n): add storage details cooldown and timeout setting labels

### DIFF
--- a/src/lang/en/settings.json
+++ b/src/lang/en/settings.json
@@ -146,5 +146,7 @@
   "version": "Version",
   "video_autoplay": "Video autoplay",
   "video_types": "Video types",
-  "webauthn_login_enabled": "WebAuthn login enabled"
+  "webauthn_login_enabled": "WebAuthn login enabled",
+  "storage_details_cooldown_seconds": "Storage details refresh cooldown (seconds)",
+  "storage_details_timeout_seconds": "Storage details background timeout (seconds)"
 }

--- a/src/lang/en/settings.json
+++ b/src/lang/en/settings.json
@@ -138,6 +138,8 @@
   },
   "sso_oidc_username_key": "SSO oidc username key",
   "sso_organization_name": "SSO organization name",
+  "storage_details_cooldown_seconds": "Storage details refresh cooldown (seconds)",
+  "storage_details_timeout_seconds": "Storage details background timeout (seconds)",
   "text_types": "Text types",
   "token": "Token",
   "transmission_seedtime": "Transmission seedtime",
@@ -146,7 +148,5 @@
   "version": "Version",
   "video_autoplay": "Video autoplay",
   "video_types": "Video types",
-  "webauthn_login_enabled": "WebAuthn login enabled",
-  "storage_details_cooldown_seconds": "Storage details refresh cooldown (seconds)",
-  "storage_details_timeout_seconds": "Storage details background timeout (seconds)"
+  "webauthn_login_enabled": "WebAuthn login enabled"
 }


### PR DESCRIPTION
## Summary / 摘要

### 1. Context & Motivation / 背景与动机
This PR accompanies the backend PR `OpenListTeam/OpenList` (which introduces asynchronous context decoupling, force-refresh cache invalidation, and singleflight deduplication for storage quota probing).

It adds the corresponding English i18n labels in `src/lang/en/settings.json` for the two newly introduced configuration options in the Admin Settings panel:
本 PR 配合后端 `OpenListTeam/OpenList` 的存储容量探测优化，在 `src/lang/en/settings.json` 中为管理后台新增的两个配置项提供标准英文国际化词条：

- **`storage_details_cooldown_seconds`**: `"Storage details refresh cooldown (seconds)"`  
  Cooldown duration in seconds to throttle high-frequency capacity queries (defaults to 0).  
  存储容量刷新冷却时间（秒，默认 0 秒）。
- **`storage_details_timeout_seconds`**: `"Storage details background timeout (seconds)"`  
  Independent timeout duration in seconds for background storage details probing (defaults to 15s).  
  存储容量后台探测超时时间（秒，默认 15 秒）。

---

### 2. Changes / 变更内容
- Added `storage_details_cooldown_seconds` and `storage_details_timeout_seconds` to `src/lang/en/settings.json`.

- [ ] This PR has breaking changes. / 此 PR 包含破坏性变更。
- [ ] This PR changes public API, config, storage format, or migration behavior. / 此 PR 修改了公开 API、配置、存储格式或迁移行为。
- [x] This PR requires corresponding changes in related repositories. / 此 PR 需要关联仓库同步修改。

Related repository PRs / 关联仓库 PR:

- OpenList: OpenListTeam/OpenList#2950

## Related Issues / 关联 Issue

- Relates to OpenListTeam/OpenList#1815, OpenListTeam/OpenList#2633, OpenListTeam/OpenList#2635

## Testing / 测试

- [x] Verified admin settings page renders translated labels properly when backend settings API returns the new keys.

## Checklist / 检查清单

- [x] I have read [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md). / 我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md)。
- [x] I confirm this contribution follows the repository license, contribution policy, and code of conduct. / 我确认此贡献符合仓库许可证、贡献规范和行为准则。
- [x] I have formatted the changed code with `prettier` where applicable. / 我已按适用情况使用 `prettier` 格式化变更代码。
- [x] I have requested review from relevant maintainers or code owners where applicable. / 我已在适用情况下请求相关维护者或代码所有者审查。

## AI Disclosure / AI 使用声明

- [x] This PR includes AI-assisted content. / 此 PR 包含 AI 辅助内容。

Tools used / 使用工具:
- [x] Gemini

Usage scope / 使用范围:
- [x] Documentation / 文档
- [x] Translation / 翻译
- [x] Review assistance / 审查辅助

- [x] I have reviewed and validated all AI-assisted content included in this PR. / 我已审核并验证此 PR 中的所有 AI 辅助内容。
- [x] I have ensured that all AI-assisted commits include `Co-Authored-By` attribution. / 我已确保所有 AI 辅助提交都包含 `Co-Authored-By` 归属信息。
- [x] I can reproduce all AI-assisted content included in this PR without any AI tools. / 我可以在没有任何 AI 工具的情况下重现此 PR 中包含的所有 AI 辅助内容。