### PR TITLE
feat(fs): add native save-from-share for cloud drivers

### DIFF
--- a/src/hooks/usePath.ts
+++ b/src/hooks/usePath.ts
@@ -180,6 +180,7 @@ export const usePath = () => {
         ObjStore.setWriteContentBypass(data.write_content_bypass)
         ObjStore.setProvider(data.provider)
         ObjStore.setDirectUploadTools(data.direct_upload_tools)
+        ObjStore.setSaveFromShare(!!data.save_from_share)
         shouldKeepState() || ObjStore.setState(State.Folder)
       },
       onlyList

--- a/src/lang/en/home.json
+++ b/src/lang/en/home.json
@@ -100,6 +100,9 @@
     "cancel_select": "Cancel Select",
     "offline_download": "Offline download",
     "offline_download-tips": "One URL per line",
+    "save_from_share": "Save from share",
+    "save_from_share-tips": "One share link per line. Passcode can be included, e.g. https://pan.quark.cn/s/xxxx 提取码: abcd",
+    "save_from_share_start": "Save",
     "offline_download_torrent": "BT Fetch",
     "offline_download_enhanced": {
       "tab_link": "Link Download",

--- a/src/pages/home/toolbar/Right.tsx
+++ b/src/pages/home/toolbar/Right.tsx
@@ -7,7 +7,11 @@ import { objStore, selectAll, State, toggleCheckbox, userCan } from "~/store"
 import { bus } from "~/utils"
 import { operations } from "./operations"
 import { IoMagnetOutline } from "solid-icons/io"
-import { AiOutlineCloudUpload, AiOutlineSetting } from "solid-icons/ai"
+import {
+  AiOutlineCloudSync,
+  AiOutlineCloudUpload,
+  AiOutlineSetting,
+} from "solid-icons/ai"
 import { RiSystemRefreshLine } from "solid-icons/ri"
 import { usePath, useRouter } from "~/hooks"
 import { Motion } from "solid-motionone"
@@ -161,6 +165,23 @@ export const Right = () => {
                 tips="offline_download"
                 onClick={() => {
                   bus.emit("tool", "offline_download")
+                }}
+              />
+            </Show>
+            <Show
+              when={
+                isFolder() &&
+                !isShare() &&
+                (userCan("write_content") || objStore.write_content_bypass) &&
+                objStore.write &&
+                objStore.save_from_share
+              }
+            >
+              <RightIcon
+                as={AiOutlineCloudSync}
+                tips="save_from_share"
+                onClick={() => {
+                  bus.emit("tool", "save_from_share")
                 }}
               />
             </Show>

--- a/src/pages/home/toolbar/SaveFromShare.tsx
+++ b/src/pages/home/toolbar/SaveFromShare.tsx
@@ -1,0 +1,103 @@
+import {
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+  Button,
+  Textarea,
+  Box,
+  VStack,
+  Text,
+  createDisclosure,
+} from "@hope-ui/solid"
+import { FolderChooseInput } from "~/components"
+import { useFetch, usePath, useRouter, useT } from "~/hooks"
+import { saveFromShare, bus, handleRespWithNotifySuccess } from "~/utils"
+import { createSignal, onCleanup } from "solid-js"
+
+export const SaveFromShare = () => {
+  const t = useT()
+  const { pathname } = useRouter()
+  const { refresh } = usePath()
+  const { isOpen, onOpen, onClose } = createDisclosure()
+  const [linkValue, setLinkValue] = createSignal("")
+  const [savePath, setSavePath] = createSignal("")
+  const [loading, submit] = useFetch(saveFromShare)
+
+  const handler = (name: string) => {
+    if (name === "save_from_share") {
+      setSavePath(pathname())
+      onOpen()
+    }
+  }
+  bus.on("tool", handler)
+  onCleanup(() => {
+    bus.off("tool", handler)
+  })
+
+  const handleClose = () => {
+    setLinkValue("")
+    onClose()
+  }
+
+  const handleSubmit = async () => {
+    if (!linkValue().trim()) return
+    const urls = linkValue()
+      .split("\n")
+      .map((u) => u.trim())
+      .filter(Boolean)
+    const resp = await submit(savePath(), urls)
+    handleRespWithNotifySuccess(resp, () => {
+      handleClose()
+      refresh(undefined, true)
+    })
+  }
+
+  return (
+    <Modal
+      size="xl"
+      blockScrollOnMount={false}
+      opened={isOpen()}
+      onClose={handleClose}
+    >
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>{t("home.toolbar.save_from_share")}</ModalHeader>
+        <ModalBody>
+          <VStack spacing="$3" alignItems="stretch">
+            <Textarea
+              placeholder={t("home.toolbar.save_from_share-tips")}
+              value={linkValue()}
+              onInput={(e) => setLinkValue(e.currentTarget.value)}
+              minH="120px"
+            />
+            <Box>
+              <Text fontSize="$sm" mb="$1" fontWeight="$medium">
+                {t("home.toolbar.offline_download_enhanced.save_path")}
+              </Text>
+              <FolderChooseInput
+                value={savePath()}
+                onChange={setSavePath}
+                id="save-from-share-path"
+              />
+            </Box>
+          </VStack>
+        </ModalBody>
+        <ModalFooter display="flex" gap="$2">
+          <Button onClick={handleClose} colorScheme="neutral">
+            {t("global.cancel")}
+          </Button>
+          <Button
+            loading={loading()}
+            onClick={handleSubmit}
+            disabled={!linkValue().trim()}
+          >
+            {t("home.toolbar.save_from_share_start")}
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  )
+}

--- a/src/pages/home/toolbar/Toolbar.tsx
+++ b/src/pages/home/toolbar/Toolbar.tsx
@@ -10,6 +10,7 @@ import { RecursiveMove } from "./RecursiveMove"
 import { RemoveEmptyDirectory } from "./RemoveEmptyDirectory"
 import { BatchRename } from "./BatchRename"
 import { OfflineDownloadEnhanced } from "./OfflineDownloadEnhanced"
+import { SaveFromShare } from "./SaveFromShare"
 import { PackageDownloadModal } from "./Download"
 import { lazy } from "solid-js"
 import { ModalWrapper } from "./ModalWrapper"
@@ -35,6 +36,7 @@ export const Modal = () => {
       <RemoveEmptyDirectory />
       <BatchRename />
       <OfflineDownloadEnhanced />
+      <SaveFromShare />
       <PackageDownloadModal />
       <ModalWrapper name="upload" title="home.toolbar.upload">
         <Upload />

--- a/src/store/obj.ts
+++ b/src/store/obj.ts
@@ -29,6 +29,7 @@ const initialObjStore = {
   header: "",
   provider: "",
   direct_upload_tools: <string[] | undefined>undefined,
+  save_from_share: false,
   state: State.Initial,
   err: "",
 }
@@ -82,6 +83,8 @@ export const ObjStore = {
   setState: (state: State) => setObjStore("state", state),
   setDirectUploadTools: (tools?: string[]) =>
     setObjStore("direct_upload_tools", tools),
+  setSaveFromShare: (enabled: boolean) =>
+    setObjStore("save_from_share", enabled),
   setErr: (err: string) => setObjStore("err", err),
 }
 

--- a/src/types/resp.ts
+++ b/src/types/resp.ts
@@ -20,6 +20,7 @@ export type FsListResp = Resp<{
   write_content_bypass: boolean
   provider: string
   direct_upload_tools?: string[]
+  save_from_share?: boolean
 }>
 
 export type SearchNode = {

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,17 +1,17 @@
 import axios, { CancelToken } from "axios"
 import {
-  PEmptyResp,
+  ArchiveMeta,
   FsGetResp,
   FsListResp,
-  Obj,
-  PResp,
   FsSearchResp,
-  RenameObj,
-  ArchiveMeta,
+  Obj,
+  PEmptyResp,
   PPageResp,
+  PResp,
+  RenameObj,
   TorrentInfo,
-  TorrentUploadParseResult,
   TorrentRapidUploadResult,
+  TorrentUploadParseResult,
 } from "~/types"
 import { r } from "."
 
@@ -222,6 +222,14 @@ export const offlineDownload = (
   delete_policy: string,
 ): PEmptyResp => {
   return r.post(`/fs/add_offline_download`, { path, urls, tool, delete_policy })
+}
+
+export const saveFromShare = (
+  path: string,
+  urls: string[],
+  password?: string,
+): PEmptyResp => {
+  return r.post("/fs/save_from_share", { path, urls, password })
 }
 
 export const fetchText = async (


### PR DESCRIPTION
## Summary / 摘要

Add a driver-level save-from-share capability so cloud storages can save files from share links into a chosen directory. Quark/UC Session implements it first; the frontend “More” menu shows the action only when the current storage supports it.

新增驱动级「分享链接转存」能力，将分享中的文件保存到指定目录。先由夸克/UC Session 实现；前端仅在当前存储支持时，在「更多」菜单中显示转存入口。

- Users can paste one or more share links (optional passcode in the same line), pick a destination folder, and save natively on the cloud drive without downloading through OpenList.
  / 用户可粘贴一条或多条分享链接（同一行可带提取码），选择目标目录后由网盘原生转存，文件不经过 OpenList 中转。
- `/api/fs/list` now returns `save_from_share` so the UI can show or hide the button.
  / `/api/fs/list` 新增 `save_from_share`，前端据此显示或隐藏按钮。
- New API: `POST /api/fs/save_from_share` with `{ path, urls, password }`. Permission matches mkdir/upload (write on the destination path).
  / 新增接口 `POST /api/fs/save_from_share`，参数为 `{ path, urls, password }`。权限与新建目录/上传一致（目标路径可写）。
- New optional driver interface `driver.SaveFromShare`. Other drivers can implement the same method without HTTP or UI changes.
  / 新增可选驱动接口 `driver.SaveFromShare`。其他网盘实现同一方法即可，无需改 HTTP 或前端。
- Quark/UC flow: parse link → share token → list share root → save → poll `/task` until completion, then invalidate directory cache.
  / 夸克/UC 流程：解析链接 → 取分享 token → 列分享根目录 → 转存 → 轮询 `/task` 直到完成，然后失效目录缓存。
- No config, storage-format, or migration changes.
  / 不涉及配置、存储格式或迁移变更。

- [ ] This PR has breaking changes.
      / 此 PR 包含破坏性变更。
- [x] This PR changes public API, config, storage format, or migration behavior.
      / 此 PR 修改了公开 API、配置、存储格式或迁移行为。
- [x] This PR requires corresponding changes in related repositories.
      / 此 PR 需要关联仓库同步修改。

Related repository PRs / 关联仓库 PR:

- OpenList:
- OpenList-Docs:

## Testing / 测试

- [ ] `go test ./...`
- [x] Manual test / 手动测试:
  - `go test ./drivers/quark_uc/ ./internal/fs/ ./internal/op/ ./server/handles/`
  - Built a local binary with the matching frontend, started `./openlist server`, added a Quark Session storage, and confirmed save-from-share from the More menu into a chosen folder.
    / 使用配套前端构建本地二进制并启动 `./openlist server`，添加夸克 Session 存储后，从「更多」菜单转存分享链接到指定目录，行为正常。

Did not run full `go test ./...`.
/ 未执行完整的 `go test ./...`。

## Checklist / 检查清单

- [x] I have read [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md).
      / 我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md)。
- [x] I confirm this contribution follows the repository license, contribution policy, and code of conduct.
      / 我确认此贡献符合仓库许可证、贡献规范和行为准则。
- [x] I have formatted the changed code with `gofmt`, `go fmt`, or `prettier` where applicable.
      / 我已按适用情况使用 `gofmt`、`go fmt` 或 `prettier` 格式化变更代码。
- [ ] I have requested review from relevant maintainers or code owners where applicable.
      / 我已在适用情况下请求相关维护者或代码所有者审查。

## AI Disclosure / AI 使用声明

- [x] This PR includes AI-assisted content.
      / 此 PR 包含 AI 辅助内容。

Tools used / 使用工具:

- [ ] ChatGPT
- [ ] Codex
- [ ] GitHub Copilot
- [ ] Claude
- [ ] Gemini
- [x] Other (please specify) / 其他（请注明）: Grok (xAI)

Usage scope / 使用范围:

- [x] Code generation / 代码生成
- [ ] Refactoring / 重构
- [ ] Documentation / 文档
- [x] Tests / 测试
- [ ] Translation / 翻译
- [ ] Review assistance / 审查辅助

- [x] I have reviewed and validated all AI-assisted content included in this PR.
      / 我已审核并验证此 PR 中的所有 AI 辅助内容。
- [ ] I have ensured that all AI-assisted commits include `Co-Authored-By` attribution.
      / 我已确保所有 AI 辅助提交都包含 `Co-Authored-By` 归属信息。
- [x] I can reproduce all AI-assisted content included in this PR without any AI tools.
      / 我可以在没有任何 AI 工具的情况下重现此 PR 中包含的所有 AI 辅助内容。