### PR TITLE
fix(manage): return to the list after saving, not into history

### DIFF
--- a/src/pages/manage/metas/AddOrEdit.tsx
+++ b/src/pages/manage/metas/AddOrEdit.tsx
@@ -123,7 +123,7 @@ const AddOrEdit = () => {
   }
 
   const t = useT()
-  const { params, back } = useRouter()
+  const { params, to } = useRouter()
   const { id } = params
   const [meta, setMeta] = createStore<Meta>({
     id: 0,
@@ -238,7 +238,7 @@ const AddOrEdit = () => {
             // TODO maybe can use handleRrespWithNotifySuccess
             handleResp(resp, () => {
               notify.success(t("global.save_success"))
-              back()
+              to("/@manage/metas")
             })
           }}
         >

--- a/src/pages/manage/shares/AddOrEdit.tsx
+++ b/src/pages/manage/shares/AddOrEdit.tsx
@@ -11,7 +11,7 @@ import { me } from "~/store"
 
 const AddOrEdit = () => {
   const t = useT()
-  const { params, back, to } = useRouter()
+  const { params, to } = useRouter()
   const { id } = params
   const [shareLoading, loadShare] = useFetch(
     (): PResp<ShareInfo> => r.get(`/share/get?id=${id}`),
@@ -192,7 +192,7 @@ const AddOrEdit = () => {
             resp,
             () => {
               notify.success(t("global.save_success"))
-              back()
+              to("/@manage/shares")
             },
             (_msg, _code) => {
               if (resp.data.id) {

--- a/src/pages/manage/storages/AddOrEdit.tsx
+++ b/src/pages/manage/storages/AddOrEdit.tsx
@@ -57,7 +57,7 @@ type Drivers = Record<string, DriverInfo>
 
 const AddOrEdit = () => {
   const t = useT()
-  const { params, back, to } = useRouter()
+  const { params, to } = useRouter()
   const { id } = params
   const [driversLoading, loadDrivers] = useFetch(
     (): PResp<Drivers> => r.get("/admin/driver/list"),
@@ -209,7 +209,7 @@ const AddOrEdit = () => {
               resp,
               () => {
                 notify.success(t("global.save_success"))
-                back()
+                to("/@manage/storages")
               },
               (msg, code) => {
                 if (resp.data.id) {

--- a/src/pages/manage/users/AddOrEdit.tsx
+++ b/src/pages/manage/users/AddOrEdit.tsx
@@ -45,7 +45,7 @@ const Permission = (props: {
 
 const AddOrEdit = () => {
   const t = useT()
-  const { params, back } = useRouter()
+  const { params, to } = useRouter()
   const { id } = params
   const [user, setUser] = createStore<User>({
     id: 0,
@@ -169,7 +169,7 @@ const AddOrEdit = () => {
               notify.success(t("global.save_success"))
               if (user.username === me().username)
                 handleResp(await (r.get("/me") as PResp<Me>), setMe)
-              back()
+              to("/@manage/users")
             })
           }}
         >


### PR DESCRIPTION
## Summary / 摘要

Saving a storage on `/@manage/storages/edit/<id>` calls `back()` — `navigate(-1)` — which assumes the previous history entry is the storage list. It often is not. Reach the edit page from a bookmark, from a reload, or from the redirect straight after logging in, and saving lands you on whatever *was* there, commonly `/@login`.

From the outside this looks exactly like being logged out by the save, but nothing is wrong: `/api/admin/storage/update` only ever answers `200`, `400` or `500`, the auth middleware aborts before the handler runs, and the session stays valid. The storage really is saved — you are just standing on the login page.

Server logs show both outcomes side by side. Entering from the list:

```
POST /api/admin/storage/update
GET  /api/admin/storage/list          ← back() returned to the list
```

Entering after a reload of the edit page:

```
POST /api/admin/storage/update
POST /api/auth/login/hash             ← back() returned to /@login
GET  /api/me
GET  /api/admin/storage/get?id=4
```

These navigate to the corresponding list instead. `useRouter().to` applies `joinBase`, so a non-root `base_path` still resolves.

- User-visible change: after a successful save in any of these four editors you always land on that editor's list, instead of wherever browser history happened to point.
- No implementation, config, storage-format or API changes.

The same `back()` sits in the three sibling editors, so they are fixed here too:

| file | now navigates to |
|---|---|
| `manage/storages/AddOrEdit.tsx` | `/@manage/storages` |
| `manage/shares/AddOrEdit.tsx` | `/@manage/shares` |
| `manage/metas/AddOrEdit.tsx` | `/@manage/metas` |
| `manage/users/AddOrEdit.tsx` | `/@manage/users` |

Each destination is the entry that editor's side-menu item already points at (`sidemenu_items.tsx`). `metas` and `users` did not bind `to` at all and now do; `back` is no longer referenced in any of the four files.

`home/previews/text-editor.tsx`, `settings/Common.tsx` and `settings/S3.tsx` also notify `save_success` but do not navigate afterwards, so they are untouched.

- [ ] This PR has breaking changes.
      / 此 PR 包含破坏性变更。
- [ ] This PR changes public API, config, storage format, or migration behavior.
      / 此 PR 修改了公开 API、配置、存储格式或迁移行为。
- [ ] This PR requires corresponding changes in related repositories.
      / 此 PR 需要关联仓库同步修改。

Related repository PRs / 关联仓库 PR:

- OpenList: —
- OpenList-Docs: —

## Testing / 测试

Reproduced on a live OpenList instance (frontend from the current release dist), and confirmed the mechanism from the server access log quoted above: the same save request produces a return to the storage list or to `/@login` purely depending on the history stack.

I have **not** run the frontend build from source (no `pnpm` toolchain set up locally), so `pnpm build` / `pnpm dev` verification is left to CI. What I did check by hand is that the same rewrite applied to the shipped minified chunk produces the intended call — `notify.success(t("global.save_success")), back()` → `to("/@manage/storages")` — and that `to` is in lexical scope there, since the failure branch two lines down already calls it.

Treating this honestly: the diagnosis is verified against a running instance, the fix follows directly from it, but the patched build itself has not been exercised in a browser yet.

- [ ] `go test ./...` — not applicable to this repository.
- [x] Manual test / 手动测试: as described above.

## Checklist / 检查清单

- [x] I have read [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md).
- [x] I confirm this contribution follows the repository license, contribution policy, and code of conduct.
- [x] I have formatted the changed code with `gofmt`, `go fmt`, or `prettier` where applicable.
- [ ] I have requested review from relevant maintainers or code owners where applicable.

## AI Disclosure / AI 使用声明

- [x] This PR includes AI-assisted content.
      / 此 PR 包含 AI 辅助内容。

Tools used / 使用工具:

- [ ] ChatGPT
- [ ] Codex
- [ ] GitHub Copilot
- [x] Claude
- [ ] Gemini
- [ ] Other (please specify) / 其他（请注明）:

Usage scope / 使用范围:

- [x] Code generation / 代码生成
- [ ] Refactoring / 重构
- [ ] Documentation / 文档
- [ ] Tests / 测试
- [ ] Translation / 翻译
- [x] Review assistance / 审查辅助

- [x] I have reviewed and validated all AI-assisted content included in this PR.
- [x] I have ensured that all AI-assisted commits include `Co-Authored-By` attribution.
- [x] I can reproduce all AI-assisted content included in this PR without any AI tools.
