### PR TITLE
fix(markdown): resolve media links in the rehype ast

### DIFF
--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -7,24 +7,27 @@ import rehypeStringify from "rehype-stringify"
 import remarkGfm from "remark-gfm"
 import remarkParse from "remark-parse"
 import remarkRehype from "remark-rehype"
-import { For, Show, createEffect, createMemo, createSignal, on } from "solid-js"
+import {
+  For,
+  Show,
+  createEffect,
+  createMemo,
+  createSignal,
+  on,
+  untrack,
+} from "solid-js"
 import { Motion } from "solid-motionone"
 import { unified } from "unified"
 import { useCDN, useParseText, useRouter } from "~/hooks"
 import { useScrollListener } from "~/pages/home/toolbar/BackTop.jsx"
-import { getMainColor, getSettingBool, me } from "~/store"
-import {
-  api,
-  loadCSS,
-  loadScriptIIFE,
-  notify,
-  pathDir,
-  pathJoin,
-  pathResolve,
-} from "~/utils"
+import { getMainColor, getSettingBool, objStore } from "~/store"
+import { loadCSS, loadScriptIIFE, notify, pathDir, pathJoin } from "~/utils"
 import { isMobile } from "~/utils/compatibility.js"
 import hljs from "highlight.js"
 import { EncodingSelect } from "."
+import { watchMediaSrc } from "./markdown/media-fallback"
+import { rehypeMedia } from "./markdown/rehype-media"
+import type { HastNode, MediaContext } from "./markdown/rehype-media"
 import "./markdown.css"
 
 type TocItem = { indent: number; text: string; tagName: string; key: string }
@@ -157,7 +160,7 @@ const { katexCSSPath, mermaidJSPath } = useCDN()
 
 async function renderMarkdown(
   content: string,
-  sanitize: boolean,
+  ctx: { sanitize: boolean } & MediaContext,
 ): Promise<{ html: string; hasMermaid: boolean }> {
   let processor = unified()
 
@@ -181,17 +184,60 @@ async function renderMarkdown(
   }
 
   processor.use(remarkRehype, { allowDangerousHtml: true }).use(rehypeRaw)
+  // resolve media urls and render the image syntax of a video as a player
+  processor.use(() => (tree: unknown) => rehypeMedia(tree as HastNode, ctx))
 
-  if (sanitize)
+  if (ctx.sanitize) {
+    const attrs = defaultSchema.attributes ?? {}
+    const allow = (tag: string, ...names: string[]) => [
+      ...(attrs[tag] ?? []),
+      ...names,
+    ]
     processor.use(rehypeSanitize, {
       ...defaultSchema,
+      // video/audio/track are not in the default element whitelist and
+      // would be stripped entirely, breaking markdown video previews
+      tagNames: [...(defaultSchema.tagNames ?? []), "video", "audio", "track"],
+      // the default only allows http/https, which drops inline base64 pictures
+      protocols: {
+        ...defaultSchema.protocols,
+        src: [...(defaultSchema.protocols?.src ?? []), "data"],
+      },
       attributes: {
-        ...defaultSchema.attributes,
+        ...attrs,
+        // `data-md-path` feeds the runtime fallback of media links
+        "*": allow("*", "data*"),
         code: [
           ["className", /^language-[\w-]+$/, "math-inline", "math-display"],
         ],
+        // attribute names are hast properties, not html attributes
+        video: allow(
+          "video",
+          "src",
+          "poster",
+          "controls",
+          "preload",
+          "autoplay",
+          "loop",
+          "muted",
+          "playsInline",
+          "crossOrigin",
+        ),
+        audio: allow(
+          "audio",
+          "src",
+          "controls",
+          "preload",
+          "autoplay",
+          "loop",
+          "muted",
+          "crossOrigin",
+        ),
+        source: allow("source", "src", "srcSet", "type", "media"),
+        track: allow("track", "src", "kind", "label", "srclang", "default"),
       },
     })
+  }
 
   if (hasMath) {
     const { default: rehypeKatex } = await import("rehype-katex")
@@ -220,45 +266,37 @@ export function Markdown(props: {
   const { isString, text } = useParseText(props.children)
   const { pathname } = useRouter()
 
+  // media urls of the markdown are relative to the dir it belongs to: the
+  // folder itself for a readme, the parent dir for a previewed file
+  const baseDir = createMemo(() =>
+    props.readme ? pathname() : pathDir(pathname()),
+  )
+  // the listing already carries the sign of every object next to the markdown
+  const siblingSigns = () => {
+    const signs = new Map<string, string>()
+    for (const obj of objStore.objs) {
+      if (obj.sign) signs.set(pathJoin(baseDir(), obj.name), obj.sign)
+    }
+    return signs
+  }
+
   const md = createMemo(() => {
     const raw = text(encoding())
-    const content =
-      !props.ext || props.ext.toLowerCase() === "md"
-        ? raw
-        : `\`\`\`${props.ext}\n${raw}\n\`\`\``
-
-    return content.replace(/!\[.*?\]\((.*?)\)/g, (match) => {
-      const name = match.match(/!\[(.*?)\]\(.*?\)/)![1]
-      const rawUrl = match.match(/!\[.*?\]\((.*?)\)/)![1]
-
-      if (
-        rawUrl.startsWith("data:image/") ||
-        rawUrl.startsWith("http://") ||
-        rawUrl.startsWith("https://") ||
-        rawUrl.startsWith("//")
-      ) {
-        return match
-      }
-
-      const resolvedPath = rawUrl.startsWith("/")
-        ? rawUrl
-        : pathResolve(props.readme ? pathname() : pathDir(pathname()), rawUrl)
-
-      const url = `${api}/d${pathJoin(me().base_path, resolvedPath)}`
-      const ans = `![${name}](${url})`
-      console.log(ans)
-      return ans
-    })
+    return !props.ext || props.ext.toLowerCase() === "md"
+      ? raw
+      : `\`\`\`${props.ext}\n${raw}\n\`\`\``
   })
 
   createEffect(
     on([md, mermaidTheme], async () => {
       setShow(false)
 
-      const { html, hasMermaid } = await renderMarkdown(
-        md(),
-        props.sanitize || getSettingBool("filter_readme_scripts"),
-      )
+      const { html, hasMermaid } = await renderMarkdown(md(), {
+        sanitize: props.sanitize || getSettingBool("filter_readme_scripts"),
+        baseDir: baseDir(),
+        // untracked: appending objects must not re-render the whole markdown
+        signs: untrack(siblingSigns),
+      })
       setMarkdownHTML(html)
 
       setTimeout(() => {
@@ -292,6 +330,7 @@ export function Markdown(props: {
           window.mermaid.run({ querySelector: ".language-mermaid" })
         }
 
+        watchMediaSrc(markdownRef())
         window.onMDRender?.()
       })
     }),

--- a/src/components/markdown.css
+++ b/src/components/markdown.css
@@ -113,6 +113,18 @@
   /* background-color: #fff; */
 }
 
+/* media referenced by a markdown file must not overflow the container */
+.markdown-body video,
+.markdown-body audio {
+  max-width: 100%;
+}
+
+.markdown-body video {
+  display: block;
+  height: auto;
+  margin: 0.5em 0;
+}
+
 .markdown-body code,
 .markdown-body kbd,
 .markdown-body pre {

--- a/src/components/markdown/media-fallback.ts
+++ b/src/components/markdown/media-fallback.ts
@@ -1,0 +1,78 @@
+import { me, password } from "~/store"
+import { fsGet, pathJoin } from "~/utils"
+
+/**
+ * Media of this deployment is linked through `/d`, which answers 401 when the
+ * target needs a signature the folder listing didn't carry - a path outside
+ * the current dir, a mounted share, or an encrypted meta. Only then the raw
+ * url is resolved, per element that actually failed to load.
+ */
+
+// a raw url may be a temporary direct link, so it is not cached forever
+const TTL = 10 * 60 * 1000
+const resolved = new Map<string, { url: string; at: number }>()
+const pending = new Map<string, Promise<string>>()
+
+function fetchRawUrl(path: string) {
+  const cached = resolved.get(path)
+  if (cached && Date.now() - cached.at < TTL) return Promise.resolve(cached.url)
+  const inflight = pending.get(path)
+  if (inflight) return inflight
+
+  const request = (async () => {
+    try {
+      const resp = await fsGet(pathJoin(me().base_path, path), password())
+      return resp.code === 200 && resp.data?.raw_url ? resp.data.raw_url : ""
+    } catch {
+      return ""
+    }
+  })().then((url) => {
+    pending.delete(path)
+    if (url) resolved.set(path, { url, at: Date.now() })
+    return url
+  })
+  pending.set(path, request)
+  return request
+}
+
+function isBroken(el: HTMLElement) {
+  if (el instanceof HTMLImageElement)
+    return el.complete && el.naturalWidth === 0
+  if (el instanceof HTMLMediaElement)
+    return el.networkState === HTMLMediaElement.NETWORK_NO_SOURCE
+  return false
+}
+
+async function retryWithRawUrl(el: HTMLElement, path: string) {
+  // one attempt per element per render, a raw url can't fail twice silently
+  el.dataset.mdRetried = "1"
+  const url = await fetchRawUrl(path)
+  if (!url) {
+    delete el.dataset.mdRetried
+    return
+  }
+  el.setAttribute("src", url)
+  // candidates of srcset win over src, so they must go away
+  el.removeAttribute("srcset")
+  el.removeAttribute("sizes")
+  // <source>/<track> are only picked up again when the host reloads
+  const host = el instanceof HTMLMediaElement ? el : el.closest("video, audio")
+  if (host instanceof HTMLMediaElement) host.load()
+}
+
+export function watchMediaSrc(root?: ParentNode | null) {
+  root
+    ?.querySelectorAll<HTMLElement>("img,video,audio,source,track")
+    .forEach((el) => {
+      const path = el.dataset.mdPath
+      if (!path || el.dataset.mdRetried) return
+      // the request may already have failed before this runs
+      if (isBroken(el)) {
+        void retryWithRawUrl(el, path)
+        return
+      }
+      el.addEventListener("error", () => void retryWithRawUrl(el, path), {
+        once: true,
+      })
+    })
+}

--- a/src/components/markdown/rehype-media.ts
+++ b/src/components/markdown/rehype-media.ts
@@ -1,0 +1,185 @@
+import { getLinkByDirAndObj } from "~/hooks/useLink"
+import type { Obj } from "~/types"
+import { api, base_path, ext, pathBase, pathDir, pathResolve } from "~/utils"
+
+/**
+ * Minimal hast shape. This runs after `rehype-raw`, so the tree only holds
+ * element/text nodes and no `raw` node is left to expand.
+ */
+export interface HastNode {
+  type: string
+  tagName?: string
+  properties?: Record<string, unknown>
+  children?: HastNode[]
+}
+
+export interface MediaContext {
+  /** storage path of the dir relative media urls are resolved against */
+  baseDir: string
+  /** storage path -> sign, taken from the folder listing when available */
+  signs: Map<string, string>
+}
+
+// `![](x.mp4)` can never be played by an <img>, so it becomes a <video>
+const VIDEO_EXTS = new Set(["mp4", "webm", "ogg", "ogv", "mov", "m4v", "mkv"])
+const MEDIA_TAGS = new Set(["img", "video", "audio", "source", "track"])
+// a link copied from this site may already carry a download/proxy prefix
+const LINK_PREFIXES: [RegExp, string][] = [
+  [/^\/sd\//, "/@s/"],
+  [/^\/sp\//, "/@s/"],
+  [/^\/[dp]\//, "/"],
+]
+
+const apiOrigin = (() => {
+  try {
+    return new URL(api).origin
+  } catch {
+    return ""
+  }
+})()
+
+/**
+ * The storage path a media url points to, or undefined when the url is not
+ * ours to rewrite (other site, inline data, malformed).
+ */
+function resolveMediaPath(raw: unknown, ctx: MediaContext) {
+  if (typeof raw !== "string") return
+  let path = raw.trim()
+  if (!path || /^(data|blob|about|javascript):/i.test(path)) return
+  // protocol-relative: an external resource
+  if (path.startsWith("//")) return
+
+  let prefixed = true
+  if (/^https?:/i.test(path)) {
+    let url: URL
+    try {
+      url = new URL(path)
+    } catch {
+      return
+    }
+    if (url.origin !== apiOrigin) return
+    path = url.pathname
+    if (base_path && (path === base_path || path.startsWith(`${base_path}/`))) {
+      path = path.slice(base_path.length) || "/"
+    }
+  } else if (path.startsWith("/")) {
+    path = pathResolve("/", path)
+  } else {
+    path = pathResolve(ctx.baseDir, path)
+    // a relative url never carries a link prefix
+    prefixed = false
+  }
+  if (prefixed) {
+    for (const [prefix, storage] of LINK_PREFIXES) {
+      if (prefix.test(path)) {
+        path = path.replace(prefix, storage)
+        break
+      }
+    }
+  }
+
+  path = path.split(/[?#]/)[0]
+  try {
+    path = decodeURIComponent(path)
+  } catch {
+    // keep it when the author wrote malformed percent encoding
+  }
+  return path.startsWith("/") ? path : undefined
+}
+
+/**
+ * The direct link of a storage path, built by the same helper the file list
+ * uses, so the share prefix (`/sd`), `pwd`, `sign` and path encoding stay
+ * consistent with the rest of the app.
+ */
+function toMediaLink(path: string, ctx: MediaContext) {
+  const obj = { name: pathBase(path), sign: ctx.signs.get(path) } as Obj
+  return getLinkByDirAndObj(
+    pathDir(path),
+    obj,
+    "direct",
+    path.startsWith("/@s"),
+    true,
+  )
+}
+
+/** href + storage path of a media url, or undefined to leave it untouched */
+function resolveUrl(raw: unknown, ctx: MediaContext) {
+  const path = resolveMediaPath(raw, ctx)
+  return path ? { path, href: toMediaLink(path, ctx) } : undefined
+}
+
+/** `{ src, srcSet }` of a media element, with every url resolved */
+function rewriteUrls(node: HastNode, ctx: MediaContext) {
+  const properties = (node.properties ??= {})
+  const src = resolveUrl(properties.src, ctx)
+  if (src) {
+    properties.src = src.href
+    // lets the runtime fallback re-resolve through /fs/get when this link
+    // turns out to need a signature that was not knowable at render time
+    properties.dataMdPath = src.path
+  }
+
+  const poster = resolveUrl(properties.poster, ctx)
+  if (poster) properties.poster = poster.href
+
+  // "a.png 1x, b.png 2x": every candidate on its own, descriptors kept
+  if (typeof properties.srcSet === "string") {
+    properties.srcSet = properties.srcSet
+      .split(",")
+      .map((candidate) => {
+        const [raw, ...descriptors] = candidate.trim().split(/\s+/)
+        const url = resolveUrl(raw, ctx)
+        return [url?.href ?? raw, ...descriptors].join(" ")
+      })
+      .join(", ")
+  }
+
+  return src
+}
+
+function toVideo(
+  properties: Record<string, unknown>,
+  src: { path: string; href: string },
+): HastNode {
+  // `alt`/`srcSet`/`sizes` mean nothing to a video element
+  const { alt, srcSet, sizes, ...rest } = properties
+  return {
+    type: "element",
+    tagName: "video",
+    properties: {
+      ...rest,
+      src: src.href,
+      dataMdPath: src.path,
+      controls: true,
+      preload: "metadata",
+    },
+    children: [],
+  }
+}
+
+/**
+ * rehype transformer: resolve media urls of the rendered markdown, and render
+ * a video referenced with the image syntax as an actual player.
+ */
+export function rehypeMedia(root: HastNode, ctx: MediaContext) {
+  const visit = (node: HastNode) => {
+    const children = node.children
+    if (!children) return
+    children.forEach((child, index) => {
+      if (child.type !== "element" || !child.tagName) return
+      if (MEDIA_TAGS.has(child.tagName)) {
+        const url = rewriteUrls(child, ctx)
+        if (
+          url &&
+          child.tagName === "img" &&
+          VIDEO_EXTS.has(ext(url.path).toLowerCase())
+        ) {
+          children[index] = toVideo(child.properties ?? {}, url)
+        }
+      }
+      visit(child)
+    })
+  }
+  visit(root)
+}


### PR DESCRIPTION
## Summary / 摘要

fix(markdown): resolve media links in the rehype ast

Media in a markdown file was handled by two string/DOM hacks stacked on
each other: a regex on the raw source rewrote relative urls into
`${api}/d/...`, and a post-render pass parsed that link back into a
storage path to look up a signed raw url. Both directions were
heuristics, and the second one made every media element fire a request
that was expected to fail.

Move the structural work into a rehype plugin that runs after
`rehype-raw` and before `rehype-sanitize`:

- resolve every media url to a storage path once, then build the link
  with getLinkByDirAndObj(), so the share prefix (/sd + pwd), the sign
  and path encoding match the rest of the app; the sign of a sibling is
  already in the folder listing, which costs no extra request
- replace an <img> whose target is a video with a <video> node, instead
  of emitting raw html into the markdown source
- handle poster, srcset, <source> and <track> too
- only /fs/get a raw url, per element, when the link actually failed to
  load (a path outside the listing, an encrypted meta); cached with a
  ttl, retried once

This also fixes: rewriting inside fenced code blocks, urls with parens
or a title, attribute injection through a crafted filename, and a
missing max-width for video. While there, the sanitize whitelist uses
hast property names now (playsInline, crossOrigin were no-ops) and
inline base64 pictures survive filtering.

fix(markdown): 用 AST 解析媒体链接，替代字符串与 DOM 两层补丁

原来先用正则把相对路径改写成 /d 链接，渲染后再从 DOM 里反解回存储路径去
换签名链接，两个方向都是启发式，且每个媒体必然先发出一个会失败的请求。

- 新增 rehype 插件（rehype-raw 之后、sanitize 之前）：解析媒体 url，复用
  getLinkByDirAndObj 生成链接，同目录文件的签名直接取列表里的，零额外请求
- 图片语法指向视频时原地替换为 <video> 节点，不再往 markdown 源里塞 html
- 同时处理 poster、srcset、<source>、<track>
- 仅当链接确实加载失败才请求 raw_url（带 TTL 缓存，单个元素只重试一次）
- 顺带修：代码块内容被正则污染、url 含括号或 title、文件名构造属性注入、
  video 无宽度约束、白名单属性名写成小写导致 playsinline/crossorigin 失效
- 中文文件夹路径也正常能解析，正常显示图片和链接到具体文件

- User-visible changes / 用户可感知的行为变化:
  - Markdown images now load correctly when `sign_all` is enabled.
  - Videos in markdown (`![](file.mp4)` or raw `<video>` tags) now render and play.
  - Media in shared-page markdown previews also works (backend routes `/@s` paths to the share API automatically).
  - External image links are untouched.
- Implementation changes / 重要实现变化:
  - After render, `fixMediaSrc` rewrites relative `src` of `img/video/audio/source` to signed raw urls obtained via `fs/get` (with caching, failure retry and a bounded concurrency pool).
  - `![]()` links pointing to video files are rewritten to `<video controls>` elements.
  - The sanitize schema now allows `video`/`audio`/`track` elements and media attributes (they were previously stripped entirely).
  - Local media links are recognized by origin and the deployment `base_path` is stripped before resolving the storage path.
  - Removed a leftover `console.log` debug statement.
- Config / storage / API / compatibility: none.
  / 无配置、存储、API 或兼容性变化。

- [ ] This PR has breaking changes.
      / 此 PR 包含破坏性变更。
- [ ] This PR changes public API, config, storage format, or migration behavior.
      / 此 PR 修改了公开 API、配置、存储格式或迁移行为。
- [ ] This PR requires corresponding changes in related repositories.
      / 此 PR 需要关联仓库同步修改。

Related repository PRs / 关联仓库 PR:

- OpenList: N/A
- OpenList-Docs: N/A

## Related Issues / 关联 Issue

N/A（无关联 Issue，本节可删除）

## Testing / 测试

- [ ] `go test ./...` — N/A, this is a frontend-only repository.
      / 不适用，本仓库为纯前端仓库，无 Go 代码。
- [x] `pnpm lint` (`tsc --noEmit`) — no errors in the changed file; the remaining errors are pre-existing and unrelated to this PR.
      / 变更文件无类型错误；其余报错为与本 PR 无关的既有问题。
- [x] `pnpm build` — succeeds.
- [x] Manual test / 手动测试:
  - Environment: OpenList-Desktop v4.2.4 (backend) serving this `dist`, with `sign_all = true`.
  - Markdown images display correctly; Network tab shows `POST /api/fs/get` returning a signed `raw_url`, and image requests hit `/p/...?sign=...` with 200.
  - `![](xxx.mp4)` renders as a playable `<video>` with controls.
  - Raw `<video src="..." controls>` tags play as well.
  - External (`http(s)` other-origin) images are unaffected.
  - Share-page previews: covered by the same code path (backend routes `/@s` to the share API), not manually verified — please double-check with a share link if possible.
      / 分享页预览未手动验证（代码路径与普通预览一致），建议维护者用分享链接补充验证。

修复前
<img width="1548" height="636" alt="image" src="https://github.com/user-attachments/assets/d8215da8-f29f-4f94-b6d8-782de1403a89" />



修复后的效果
<img width="1695" height="1040" alt="image" src="https://github.com/user-attachments/assets/e382c358-f9cc-438e-bd90-2272d6397af4" />


<img width="1889" height="1092" alt="image" src="https://github.com/user-attachments/assets/461d8532-b9cc-4017-9c7d-343be5d0c156" />

测试用的md代码，媒体和md是在同一个目录下
```md
## 2026-08 测试md
2026-08-16 05:04 
测试111

<video src="测试视频1.mp4" controls></video>
979 Likes, 92 Retweets, 1 Replies


2022-04-02 04:34 [src]

测试222
[![](2022-05-03-08-20-img_16.jpg)]
411 Likes, 20 Retweets, 7 Replies

测试
[![](2022-05-03-08-20-img_17.jpg)]
411 Likes, 20 Retweets, 7 Replies


```



## Checklist / 检查清单

- [x] I have read CONTRIBUTING.
      / 我已阅读 CONTRIBUTING。
- [x] I confirm this contribution follows the repository license, contribution policy, and code of conduct.
      / 我确认此贡献符合仓库许可证、贡献规范和行为准则。
- [x] I have formatted the changed code with `gofmt`, `go fmt`, or `prettier` where applicable.
      / 变更代码遵循项目 prettier 风格（与现有文件一致；本地未运行 prettier 命令）。
- [ ] I have requested review from relevant maintainers or code owners where applicable.
      / 不适用（未请求维护者审查）。

## AI Disclosure / AI 使用声明

This PR includes AI-assisted content (code generation) produced with Qoder (Lingma). The core fix was manually verified end-to-end (images and videos render correctly with `sign_all` enabled).

此 PR 包含使用 Qoder (Lingma) 生成的 AI 辅助内容（代码生成），核心修复已端到端手动验证（sign_all 开启时图片、视频均可正常预览）。

- [x] This PR includes AI-assisted content.
      / 此 PR 包含 AI 辅助内容。

Tools used / 使用工具:

- [ ] ChatGPT
- [ ] Codex
- [ ] GitHub Copilot
- [ ] Claude
- [ ] Gemini
- [x] Other (please specify) / 其他（请注明）: Qoder (Lingma)

Usage scope / 使用范围:

- [x] Code generation / 代码生成
- [ ] Refactoring / 重构
- [ ] Documentation / 文档
- [ ] Tests / 测试
- [ ] Translation / 翻译
- [ ] Review assistance / 审查辅助

- [x] I have reviewed and validated all AI-assisted content included in this PR.
      / 我已审核并验证此 PR 中的所有 AI 辅助内容。
- [ ] I have ensured that all AI-assisted commits include `Co-Authored-By` attribution.
      / 我已确保所有 AI 辅助提交都包含 `Co-Authored-By` 归属信息。（**当前 commit 未包含**，见下方说明）
- [ ] I can reproduce all AI-assisted content included in this PR without any AI tools.
      / 我可以在没有任何 AI 工具的情况下重现此 PR 中包含的所有 AI 辅助内容。（**无法勾选**，如实声明）