### PR TITLE
feat: add system initialization setup wizard

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -23,6 +23,7 @@ import { globalStyles } from "./theme"
 const Home = lazy(() => import("~/pages/home/Layout"))
 const Manage = lazy(() => import("~/pages/manage"))
 const Login = lazy(() => import("~/pages/login"))
+const Init = lazy(() => import("~/pages/init"))
 const Test = lazy(() => import("~/pages/test"))
 
 const App: Component = () => {
@@ -43,6 +44,7 @@ const App: Component = () => {
   })
 
   const [err, setErr] = createSignal<string[]>([])
+  const [initialized, setInitialized] = createSignal<boolean | null>(null)
   const [loading, data] = useLoading(() =>
     Promise.all([
       (async () => {
@@ -59,9 +61,25 @@ const App: Component = () => {
           (e) => setErr(err().concat(e)),
         )
       })(),
+      (async () => {
+        handleRespWithoutAuthAndNotify(
+          (await r.get("/public/init_status")) as Resp<{
+            initialized: boolean
+          }>,
+          (data) => setInitialized(data.initialized),
+          (e) => setErr(err().concat(e)),
+        )
+      })(),
     ]),
   )
   data()
+
+  // 系统未初始化时，自动跳转到安装向导
+  createEffect(() => {
+    if (initialized() === false && !pathname().startsWith("/@init")) {
+      to("/@init", true)
+    }
+  })
   return (
     <>
       <Portal>
@@ -83,6 +101,7 @@ const App: Component = () => {
           <Routes base={base_path}>
             <Route path="/@test" component={Test} />
             <Route path="/@login" component={Login} />
+            <Route path="/@init" component={Init} />
             <Route
               path="/@manage/*"
               element={

--- a/src/lang/en/entry.ts
+++ b/src/lang/en/entry.ts
@@ -4,6 +4,7 @@ import global from "./global.json"
 import home from "./home.json"
 import index from "./index.json"
 import indexes from "./indexes.json"
+import init from "./init.json"
 import login from "./login.json"
 import manage from "./manage.json"
 import metas from "./metas.json"
@@ -21,6 +22,7 @@ export const dict = {
   home,
   index,
   indexes,
+  init,
   login,
   manage,
   metas,

--- a/src/lang/en/init.json
+++ b/src/lang/en/init.json
@@ -1,0 +1,12 @@
+{
+  "setup_to": "Setup",
+  "title": "Initialize OpenList",
+  "username-tips": "Admin username",
+  "password-tips": "Set admin password",
+  "confirm_password-tips": "Confirm password",
+  "site_title-tips": "Site title",
+  "setup": "Initialize",
+  "success": "Initialized successfully, please login",
+  "password_mismatch": "Passwords do not match",
+  "password_too_short": "Password must be at least 4 characters"
+}

--- a/src/pages/init/index.tsx
+++ b/src/pages/init/index.tsx
@@ -1,0 +1,153 @@
+import {
+  Image,
+  Center,
+  Flex,
+  Heading,
+  Input,
+  Button,
+  useColorModeValue,
+  VStack,
+} from "@hope-ui/solid"
+import { createMemo, createSignal, onMount } from "solid-js"
+import { SwitchColorMode, SwitchLanguageWhite } from "~/components"
+import { useLoading, useT, useTitle, useRouter } from "~/hooks"
+import { getSetting } from "~/store"
+import { r, notify, handleRespWithoutAuthAndNotify } from "~/utils"
+import { Resp } from "~/types"
+import LoginBg from "../login/LoginBg"
+
+const Init = () => {
+  const logos = getSetting("logo").split("\n")
+  const logo = useColorModeValue(logos[0], logos.pop())
+  const t = useT()
+  const title = createMemo(
+    () => `${t("init.setup_to")} ${getSetting("site_title")}`,
+  )
+  useTitle(title)
+  const bgColor = useColorModeValue("white", "$neutral1")
+  const { to } = useRouter()
+
+  const [username, setUsername] = createSignal("admin")
+  const [password, setPassword] = createSignal("")
+  const [confirmPassword, setConfirmPassword] = createSignal("")
+  const [siteTitle, setSiteTitle] = createSignal(
+    getSetting("site_title") || "OpenList",
+  )
+
+  // 若系统已初始化，跳转到登录页
+  onMount(async () => {
+    const resp = (await r.get("/public/init_status")) as Resp<{
+      initialized: boolean
+    }>
+    if (resp.code === 200 && resp.data?.initialized) {
+      to("/@login", true)
+    }
+  })
+
+  const [loading, data] = useLoading(() =>
+    r.post("/public/init/setup", {
+      username: username(),
+      password: password(),
+      site_title: siteTitle(),
+    }),
+  )
+
+  const submit = async () => {
+    if (password().length < 4) {
+      notify.error(t("init.password_too_short"))
+      return
+    }
+    if (password() !== confirmPassword()) {
+      notify.error(t("init.password_mismatch"))
+      return
+    }
+    const resp = await data()
+    handleRespWithoutAuthAndNotify(
+      resp,
+      () => {
+        notify.success(t("init.success"))
+        to("/@login", true)
+      },
+      (msg) => notify.error(msg),
+    )
+  }
+
+  return (
+    <Center zIndex="$docked" w="$full" h="100vh">
+      <VStack
+        bgColor={bgColor()}
+        rounded="$xl"
+        p="24px"
+        w={{
+          "@initial": "90%",
+          "@sm": "364px",
+        }}
+        spacing="$4"
+      >
+        <Flex alignItems="center" justifyContent="space-around">
+          <Image mr="$2" boxSize="$12" src={logo()} />
+          <Heading color="$info9" fontSize="$2xl">
+            {t("init.title")}
+          </Heading>
+        </Flex>
+        <Input
+          name="username"
+          placeholder={t("init.username-tips")}
+          value={username()}
+          onInput={(e) => setUsername(e.currentTarget.value)}
+        />
+        <Input
+          name="password"
+          type="password"
+          placeholder={t("init.password-tips")}
+          value={password()}
+          onInput={(e) => setPassword(e.currentTarget.value)}
+        />
+        <Input
+          name="confirm_password"
+          type="password"
+          placeholder={t("init.confirm_password-tips")}
+          value={confirmPassword()}
+          onInput={(e) => setConfirmPassword(e.currentTarget.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              submit()
+            }
+          }}
+        />
+        <Input
+          name="site_title"
+          placeholder={t("init.site_title-tips")}
+          value={siteTitle()}
+          onInput={(e) => setSiteTitle(e.currentTarget.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              submit()
+            }
+          }}
+        />
+        <Button
+          colorScheme="primary"
+          w="$full"
+          loading={loading()}
+          onClick={submit}
+        >
+          {t("init.setup")}
+        </Button>
+        <Flex
+          mt="$2"
+          justifyContent="space-evenly"
+          alignItems="center"
+          color="$neutral10"
+          w="$full"
+        >
+          <SwitchLanguageWhite />
+          <SwitchColorMode />
+        </Flex>
+      </VStack>
+      <LoginBg />
+    </Center>
+  )
+}
+
+export default Init

--- a/src/pages/init/index.tsx
+++ b/src/pages/init/index.tsx
@@ -10,9 +10,9 @@ import {
 } from "@hope-ui/solid"
 import { createMemo, createSignal, onMount } from "solid-js"
 import { SwitchColorMode, SwitchLanguageWhite } from "~/components"
-import { useLoading, useT, useTitle, useRouter } from "~/hooks"
+import { useLoading, useT, useTitle } from "~/hooks"
 import { getSetting } from "~/store"
-import { r, notify, handleRespWithoutAuthAndNotify } from "~/utils"
+import { base_path, r, notify, handleRespWithoutAuthAndNotify } from "~/utils"
 import { Resp } from "~/types"
 import LoginBg from "../login/LoginBg"
 
@@ -25,7 +25,6 @@ const Init = () => {
   )
   useTitle(title)
   const bgColor = useColorModeValue("white", "$neutral1")
-  const { to } = useRouter()
 
   const [username, setUsername] = createSignal("admin")
   const [password, setPassword] = createSignal("")
@@ -40,7 +39,9 @@ const Init = () => {
       initialized: boolean
     }>
     if (resp.code === 200 && resp.data?.initialized) {
-      to("/@login", true)
+      // 已初始化：整页刷新跳转，确保 App 重新读取 init_status 为 true，
+      // 避免 SPA 跳转被 App 的「未初始化」检测再次拉回本页形成循环。
+      window.location.href = base_path + "/@login"
     }
   })
 
@@ -66,7 +67,8 @@ const Init = () => {
       resp,
       () => {
         notify.success(t("init.success"))
-        to("/@login", true)
+        // 整页刷新跳转登录页，让 App 重新挂载并读取 init_status / settings
+        window.location.href = base_path + "/@login"
       },
       (msg) => notify.error(msg),
     )


### PR DESCRIPTION
# PR: 系统初始化（安装向导）功能

## 概述 / Overview
<!--
PR title / PR 标题:
- Use Conventional Commits: `type(scope): summary`
- Allowed types: `feat`, `docs`, `fix`, `style`, `refactor`, `chore`
- Scope is required by the current PR title check.
- For breaking changes, add `!`: `feat(driver)!: change auth flow`

为 OpenList 增加完整的**系统初始化（安装向导）**能力：首次部署时不再自动创建随机密码的管理员账号，而是引导用户通过 Web 安装向导设置管理员账号、密码和站点名称等初始参数，完成后再进入登录流程。
建议标题 / Suggested title:
feat(setup): add system initialization setup wizard
-->

Go 后端与 TS 后端实现同一套公开 API，前端仅需对接一套接口即可同时支持两种后端。
## Summary / 摘要

> Add a full **system initialization (setup wizard)** to OpenList. On first deployment the admin account is no longer auto-created with a random password; instead a web wizard guides the user through setting the admin username/password and site title before entering the login flow. Both Go and TS backends expose the same public API, so the frontend works against both with a single integration.
<!--
Briefly describe what changed and why.
简要说明改了什么，以及为什么需要改。
-->

---
为 OpenList 增加**系统初始化（安装向导）**能力。首次部署时不再自动创建随机密码的管理员账号，而是通过 Web 安装向导引导用户设置管理员账号、密码与站点名称，完成后再进入登录流程。此举消除「首次启动密码只打印在日志里」这一易被忽略的安全隐患，同时提供一致的首次部署体验。

## 设计 / Design
<!--
- List user-visible behavior changes.
- List important implementation changes.
- Mention config, storage, API, or compatibility changes if any.
-->

### 行为变更 / Behavior Change
- **行为变化（用户可感知）**：全新部署不再自动创建随机密码的 `admin` 账号，前端会检测「未初始化」状态并自动跳转到 `/@init` 安装向导。
- **实现变化**：
  - 将 `bootstrap/data/initUser` 拆分为 `initAdmin` + `initGuest`；未初始化且未设置 `OPENLIST_ADMIN_PASSWORD`、非 `--dev` 模式时，`initAdmin` 直接返回，不再自动创建管理员。
  - 新增 `server/handles/setup.go`，实现 `InitStatus` 与 `InitSetup` 两个 handler。
- **API 变化**：新增公开 API `GET /api/public/init_status` 与 `POST /api/public/init/setup`。
- **兼容性**：设置 `OPENLIST_ADMIN_PASSWORD` 环境变量或 `--dev` 模式时仍自动初始化（保持现有部署/CI 行为不变）；数据库表创建（GORM AutoMigrate）逻辑不变。

| 场景 | 之前 | 现在 |
|------|------|------|
| 首次部署，无环境变量 | 自动创建 `admin` + 随机密码（打印到日志） | **不创建 admin**，系统进入「未初始化」状态，前端跳转到 `/@init` |
| 设置了 `OPENLIST_ADMIN_PASSWORD`（Go）/ `ADMIN_PASSWORD`（TS） | 用该密码自动建 admin | **保持不变**（自动初始化，兼容现有部署） |
| Go 开发模式（`--dev`） | 自动建 `admin/admin` | **保持不变** |
| 数据库表创建 | 启动时自动迁移 | **保持不变**（GORM AutoMigrate / KV 存储） |
- [x] This PR has breaking changes.
      / 此 PR 包含破坏性变更。
- [x] This PR changes public API, config, storage format, or migration behavior.
      / 此 PR 修改了公开 API、配置、存储格式或迁移行为。
- [x] This PR requires corresponding changes in related repositories.
      / 此 PR 需要关联仓库同步修改。

### 新增公开 API / New Public API
Related repository PRs / 关联仓库 PR:

| 方法 | 路径 | 说明 |
|------|------|------|
| GET | `/api/public/init_status` | 返回 `{ initialized: boolean }`，前端据此判断是否跳转安装向导 |
| POST | `/api/public/init/setup` | 执行初始化，请求体 `{ username, password, site_title }` |
- OpenList-Frontend: `feat/init-setup`（安装向导页面，待创建 PR）
- OpenList-Docs: 暂无（如有安装向导文档需求，后续补充）
- OpenList-Worker（TS 后端）：已直接提交至 `main`（`afabd9b`），非 PR

初始化判定标准：**存在已设置密码的管理员账号（`role = admin`）**。
## Related Issues / 关联 Issue

---
<!--
Use `Closes #123`, `Fixes #123`, or `Relates to #123`.
Remove this section if not applicable.
-->

## 改动清单 / Changes
不适用 / Not applicable.

### 1. Go 后端（`OpenList-Backends`）
## Testing / 测试

- `internal/bootstrap/data/user.go`
  - 将 `initUser` 拆分为 `initAdmin` + `initGuest`
  - `initAdmin`：未初始化且非 Dev、未设置 `OPENLIST_ADMIN_PASSWORD` 时**直接返回**，不再自动创建管理员
- `server/handles/setup.go`（新增）
  - `InitStatus`：读取 admin 是否存在，返回初始化状态
  - `InitSetup`：校验已初始化状态与密码长度（≥4），创建管理员并写入站点名称设置项（`conf.SiteTitle`）
- `server/router.go`
  - 注册 `GET/POST /api/public/init_status` 与 `POST /api/public/init/setup`
<!--
Describe commands, platforms, and manual checks.
If not tested, explain why.
-->

### 2. TS 后端（`OpenList-TSWorker`）
- [x] `go build ./...`（通过）
- [ ] `go test ./...`（未运行，本改动无新增单测，建议合并前执行）
- [ ] Manual test / 手动测试:
  - [ ] 全新部署（不设置 `OPENLIST_ADMIN_PASSWORD`）→ 前端应自动跳转 `/@init` 安装向导
  - [ ] 填写管理员账号/密码/站点名称并提交 → 跳转登录页，使用设置的账号密码可正常登录
  - [ ] 设置 `OPENLIST_ADMIN_PASSWORD` 后部署 → 跳过向导，直接用该密码登录（兼容性）
  - [ ] `--dev` 模式 → 仍自动创建 `admin/admin`

- `server/auth.ts`
  - `getOrInitUsers`：未设置 `ADMIN_PASSWORD` 时不再生成随机密码，仅创建 guest，admin 交由安装向导
  - admin 识别从 `username === "admin"` 统一改为 `role === 2`（支持自定义管理员用户名）
- `server/public.ts`
  - 新增 `GET /api/public/init_status` 与 `POST /api/public/init/setup`
  - 支持「admin 已存在但密码为空」的更新场景
- `server/default_credentials.test.ts`
  - 同步更新 2 个依赖旧行为的测试用例
## Checklist / 检查清单

### 3. 前端（`OpenList-Frontend`）
- [x] I have read [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md).
      / 我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md)。
- [x] I confirm this contribution follows the repository license, contribution policy, and code of conduct.
      / 我确认此贡献符合仓库许可证、贡献规范和行为准则。
- [x] I have formatted the changed code with `gofmt`, `go fmt`, or `prettier` where applicable.
      / 我已按适用情况使用 `gofmt`、`go fmt` 或 `prettier` 格式化变更代码。
- [ ] I have requested review from relevant maintainers or code owners where applicable.
      / 我已在适用情况下请求相关维护者或代码所有者审查。

- `pages/init/index.tsx`（新增）
  - 安装向导页面：管理员用户名 / 密码 / 确认密码 / 站点名称
  - 已初始化时自动跳转登录页，密码校验（长度 ≥4、两次一致）
- `app/App.tsx`
  - 新增 `/@init` 路由
  - 应用启动时请求 `init_status`，未初始化自动跳转 `/@init`
- `lang/en/init.json` + `lang/en/entry.ts`
  - 新增安装向导 i18n 文案
## AI Disclosure / AI 使用声明

---
<!--
Please disclose any substantial AI assistance used in this PR.
Minor AI assistance, such as typo fixes, autocomplete, formatting suggestions,
or wording polish, does not need to be disclosed.
Remove this section if not applicable.

## 安装向导流程 / Setup Wizard Flow
Deliberate non-disclosure may be treated as a trust and compliance issue.
故意隐瞒 AI 使用情况可能被视为信任与合规问题。
-->

```mermaid
graph TD
    A[访问站点] --> B{GET /api/public/init_status}
    B -->|initialized = true| C[正常登录流程]
    B -->|initialized = false| D[跳转 /@init 安装向导]
    D --> E[填写管理员账号/密码/站点名称]
    E --> F{POST /api/public/init/setup}
    F -->|成功| G[跳转登录页]
    F -->|已初始化/校验失败| D
```
- [x] This PR includes AI-assisted content.
      / 此 PR 包含 AI 辅助内容。

---
Tools used / 使用工具:

## 测试 / Testing
- [ ] ChatGPT
- [ ] Codex
- [ ] GitHub Copilot
- [ ] Claude
- [ ] Gemini
- [x] Other (please specify) / 其他（请注明）: Deepseek-V4-Pro (CodeBuddy)

- **Go 后端**：`go build ./...` 通过
- **TS 后端**：更新后的 `default_credentials.test.ts` 覆盖新行为（未初始化不自动建 admin、空密码保持为空）
- **前端**：lint 通过
- **手动验证**：
  1. 全新部署（无 `ADMIN_PASSWORD`/`OPENLIST_ADMIN_PASSWORD`）→ 首页应自动跳转 `/@init`
  2. 填写并提交安装向导 → 跳转登录页，用设置的账号密码可正常登录
  3. 设置 `ADMIN_PASSWORD`/`OPENLIST_ADMIN_PASSWORD` 后部署 → 跳过向导，直接用该密码登录（兼容性）
Usage scope / 使用范围:

---
- [x] Code generation / 代码生成
- [ ] Refactoring / 重构
- [ ] Documentation / 文档
- [x] Tests / 测试
- [ ] Translation / 翻译
- [ ] Review assistance / 审查辅助

## 提交方式 / Submission

| 仓库 | 分支 | 提交方式 |
|------|------|---------|
| `OpenList-TSWorker` | `main` | 直接 commit |
| `OpenList-Backends` | `feat/init-setup` | PR（base: `main`） |
| `OpenList-Frontend` | `feat/init-setup` | PR（base: `main`） |

---

## Checklist

- [x] Go 后端初始化 API 与自动建 admin 行为调整
- [x] TS 后端初始化 API 与自动建 admin 行为调整
- [x] 前端安装向导页面与路由
- [x] i18n 文案
- [x] TS 后端相关测试同步更新
- [x] 双后端行为对齐（API 路径、初始化判定、环境变量兼容）
- [x] I have reviewed and validated all AI-assisted content included in this PR.
      / 我已审核并验证此 PR 中的所有 AI 辅助内容。
- [ ] I have ensured that all AI-assisted commits include `Co-Authored-By` attribution.
      / 我已确保所有 AI 辅助提交都包含 `Co-Authored-By` 归属信息。
- [ ] I can reproduce all AI-assisted content included in this PR without any AI tools.
      / 我可以在没有任何 AI 工具的情况下重现此 PR 中包含的所有 AI 辅助内容。

