### PR TITLE
fix(release): switch to edge after accidentally enabling release immutability

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -98,9 +98,9 @@ jobs:
       - name: Get current tag
         id: get_current_tag
         run: |
-          # Remove existing tag `rolling`, since `rolling` should always point to the latest commit
+          # Remove existing tag `edge`, since `edge` should always point to the latest commit
           # This is necessary to avoid conflicts with the changelog generation
-          git tag -d rolling 2>/dev/null || true
+          git tag -d edge 2>/dev/null || true
 
           # Get the current tag
           CURRENT_TAG=$(git describe --tags --abbrev=0)

--- a/.github/workflows/build_rolling.yml
+++ b/.github/workflows/build_rolling.yml
@@ -2,7 +2,7 @@
 #
 # This will:
 #
-# - Upload the release assets to GitHub (always git tagged `rolling`).
+# - Upload the release assets to GitHub (always git tagged `edge`).
 #
 # This workflow can be triggered on pushes to the `main` branch, or manually via the GitHub Actions UI.
 
@@ -56,7 +56,7 @@ jobs:
         run: |
           version=$(cat dist/VERSION)
           echo "version=$version" >> $GITHUB_OUTPUT
-          echo "tag_name=rolling" >> $GITHUB_OUTPUT
+          echo "tag_name=edge" >> $GITHUB_OUTPUT
 
       - name: Remove the existing pre-release
         run: gh release delete ${{ steps.version.outputs.tag_name }} --cleanup-tag --yes || true

--- a/build.sh
+++ b/build.sh
@@ -114,7 +114,7 @@ validate_git_tag() {
 
 # Fallback to default git tag for development builds
 fallback_git_tag() {
-    git tag -d rolling >/dev/null 2>&1 || true
+    git tag -d edge >/dev/null 2>&1 || true
     git_version=$(git describe --abbrev=0 --tags 2>/dev/null || echo "v0.0.0")
     git_version_clean=${git_version#v}
     git_version_clean=${git_version_clean%%-*}
@@ -149,11 +149,11 @@ build_project() {
     log_step "==== Building i18n ===="
     if [[ "$SKIP_I18N" == "false" ]]; then
         if ! pnpm i18n:release; then
-            log_warning "Crowdin download failed, falling back to the rolling beta release"
-            fetch_i18n_from_release "rolling" || true
+            log_warning "Crowdin download failed, falling back to the edge beta release"
+            fetch_i18n_from_release "edge" || true
         fi
     else
-        fetch_i18n_from_release "rolling" || true
+        fetch_i18n_from_release "edge" || true
     fi
 
     # Always generate entry.ts and fill missing translation files for all languages
@@ -170,7 +170,7 @@ build_project() {
 
 # Fetch i18n files from release if skip-i18n flag is set
 fetch_i18n_from_release() {
-    local release_tag=${1:-rolling}
+    local release_tag=${1:-edge}
 
     log_warning "Trying to fetch i18n files from GitHub release: $release_tag"
     release_response=$(curl -fsSL "https://api.github.com/repos/OpenListTeam/OpenList-Frontend/releases/tags/$release_tag") || {


### PR DESCRIPTION
## Summary / 摘要

Release immutability was accidentally enabled for the frontend rolling release, preventing its replacement. Switch the frontend prerelease tag to edge to restore development releases.

- Publish frontend prereleases with the edge tag.
- Update local tag cleanup and i18n release fallbacks to edge.

- [ ] This PR has breaking changes.
      / 此 PR 包含破坏性变更。
- [ ] This PR changes public API, config, storage format, or migration behavior.
      / 此 PR 修改了公开 API、配置、存储格式或迁移行为。
- [x] This PR requires corresponding changes in related repositories.
      / 此 PR 需要关联仓库同步修改。

Related repository PRs / 关联仓库 PR:

- OpenList: https://github.com/OpenListTeam/OpenList/pull/3052

## Testing / 测试

Builds and manual release tests were not run as requested for this minimal rename. The commit hook successfully ran lint-staged and Prettier on the changed workflow files.

- [ ] Manual test / 手动测试: Release publishing was not exercised.

## Checklist / 检查清单

- [ ] I have read [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md).
      / 我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md)。
- [ ] I confirm this contribution follows the repository license, contribution policy, and code of conduct.
      / 我确认此贡献符合仓库许可证、贡献规范和行为准则。
- [ ] I have formatted the changed code with `gofmt`, `go fmt`, or `prettier` where applicable.
      / 我已按适用情况使用 `gofmt`、`go fmt` 或 `prettier` 格式化变更代码。
- [ ] I have requested review from relevant maintainers or code owners where applicable.
      / 我已在适用情况下请求相关维护者或代码所有者审查。

## AI Disclosure / AI 使用声明

- [x] This PR includes AI-assisted content.
      / 此 PR 包含 AI 辅助内容。

Tools used / 使用工具:

- [ ] ChatGPT
- [x] Codex
- [ ] GitHub Copilot
- [ ] Claude
- [ ] Gemini
- [ ] Other (please specify) / 其他（请注明）:

Usage scope / 使用范围:

- [x] Code generation / 代码生成
- [ ] Refactoring / 重构
- [ ] Documentation / 文档
- [ ] Tests / 测试
- [ ] Translation / 翻译
- [ ] Review assistance / 审查辅助

Codex applied the requested tag changes and drafted the commit and PR descriptions under human direction.

- [ ] I have reviewed and validated all AI-assisted content included in this PR.
      / 我已审核并验证此 PR 中的所有 AI 辅助内容。
- [x] I have ensured that all AI-assisted commits include `Co-Authored-By` attribution.
      / 我已确保所有 AI 辅助提交都包含 `Co-Authored-By` 归属信息。
- [ ] I can reproduce all AI-assisted content included in this PR without any AI tools.
      / 我可以在没有任何 AI 工具的情况下重现此 PR 中包含的所有 AI 辅助内容。
