### PR TITLE
fix(manage): return to list pages after saving editors

### DIFF
--- a/src/pages/manage/metas/AddOrEdit.tsx
+++ b/src/pages/manage/metas/AddOrEdit.tsx
@@ -123,7 +123,7 @@ const AddOrEdit = () => {
   }
 
   const t = useT()
-  const { params, back } = useRouter()
+  const { params, to } = useRouter()
   const { id } = params
   const [meta, setMeta] = createStore<Meta>({
     id: 0,
@@ -143,12 +143,12 @@ const AddOrEdit = () => {
     header: "",
     header_sub: false,
   })
-  const [metaLoading, loadMeta] = useFetch((): PResp<Meta> =>
-    r.get(`/admin/meta/get?id=${id}`),
+  const [metaLoading, loadMeta] = useFetch(
+    (): PResp<Meta> => r.get(`/admin/meta/get?id=${id}`),
   )
   const [users, setUsers] = createSignal<User[]>([])
-  const [getUsersLoading, getUsers] = useFetch((): PPageResp<User> =>
-    r.get("/admin/user/list"),
+  const [getUsersLoading, getUsers] = useFetch(
+    (): PPageResp<User> => r.get("/admin/user/list"),
   )
 
   const initEdit = async () => {
@@ -238,7 +238,7 @@ const AddOrEdit = () => {
             // TODO maybe can use handleRrespWithNotifySuccess
             handleResp(resp, () => {
               notify.success(t("global.save_success"))
-              back()
+              to("/@manage/metas", false, { replace: true })
             })
           }}
         >

--- a/src/pages/manage/shares/AddOrEdit.tsx
+++ b/src/pages/manage/shares/AddOrEdit.tsx
@@ -11,7 +11,7 @@ import { me } from "~/store"
 
 const AddOrEdit = () => {
   const t = useT()
-  const { params, back, to } = useRouter()
+  const { params, to } = useRouter()
   const { id } = params
   const [shareLoading, loadShare] = useFetch(
     (): PResp<ShareInfo> => r.get(`/share/get?id=${id}`),
@@ -192,7 +192,7 @@ const AddOrEdit = () => {
             resp,
             () => {
               notify.success(t("global.save_success"))
-              back()
+              to("/@manage/shares", false, { replace: true })
             },
             (_msg, _code) => {
               if (resp.data.id) {

--- a/src/pages/manage/storages/AddOrEdit.tsx
+++ b/src/pages/manage/storages/AddOrEdit.tsx
@@ -57,7 +57,7 @@ type Drivers = Record<string, DriverInfo>
 
 const AddOrEdit = () => {
   const t = useT()
-  const { params, back, to } = useRouter()
+  const { params, to } = useRouter()
   const { id } = params
   const [driversLoading, loadDrivers] = useFetch(
     (): PResp<Drivers> => r.get("/admin/driver/list"),
@@ -209,7 +209,7 @@ const AddOrEdit = () => {
               resp,
               () => {
                 notify.success(t("global.save_success"))
-                back()
+                to("/@manage/storages", false, { replace: true })
               },
               (msg, code) => {
                 if (resp.data.id) {

--- a/src/pages/manage/users/AddOrEdit.tsx
+++ b/src/pages/manage/users/AddOrEdit.tsx
@@ -45,7 +45,7 @@ const Permission = (props: {
 
 const AddOrEdit = () => {
   const t = useT()
-  const { params, back } = useRouter()
+  const { params, to } = useRouter()
   const { id } = params
   const [user, setUser] = createStore<User>({
     id: 0,
@@ -58,8 +58,8 @@ const AddOrEdit = () => {
     sso_id: "",
     allow_ldap: false,
   })
-  const [userLoading, loadUser] = useFetch((): PResp<User> =>
-    r.get(`/admin/user/get?id=${id}`),
+  const [userLoading, loadUser] = useFetch(
+    (): PResp<User> => r.get(`/admin/user/get?id=${id}`),
   )
 
   const initEdit = async () => {
@@ -169,7 +169,7 @@ const AddOrEdit = () => {
               notify.success(t("global.save_success"))
               if (user.username === me().username)
                 handleResp(await (r.get("/me") as PResp<Me>), setMe)
-              back()
+              to("/@manage/users", false, { replace: true })
             })
           }}
         >


### PR DESCRIPTION
## Summary / 摘要

Saving a management editor currently navigates backward in browser history, which can return to a login page or another unrelated page when the editor was opened directly.

- Navigate to the corresponding storage, share, metadata or user list after a successful save.
- Replace the current editor history entry so browser Back does not reopen the just-saved form.
- Preserve base-path handling through useRouter().to.
- Apply Prettier formatting to the affected editors.

- [ ] This PR has breaking changes.
      / 此 PR 包含破坏性变更。
- [ ] This PR changes public API, config, storage format, or migration behavior.
      / 此 PR 修改了公开 API、配置、存储格式或迁移行为。
- [ ] This PR requires corresponding changes in related repositories.
      / 此 PR 需要关联仓库同步修改。

## Related Issues / 关联 Issue

- Closes #657: 不接受改动过小

The diagnosis in #657 was reviewed against the current router and four editors. This separate implementation also uses replace navigation, addressing the history-entry concern raised during that PR's review. The original PR is not modified by this contribution.

## Testing / 测试

- [x] Prettier formatting and the lint-staged commit hook.
- [x] Compared TypeScript diagnostics against the original versions of all four files: 44 diagnostics before and after, identical file/code/message results.
- [ ] Manual test / 手动测试: Browser navigation was not exercised.

The full TypeScript check does not pass in the current checkout because of missing modules and existing type errors. No new diagnostics were introduced by these changes. No dependencies were installed.

## Checklist / 检查清单

- [ ] I have read [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md).
      / 我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md)。
- [ ] I confirm this contribution follows the repository license, contribution policy, and code of conduct.
      / 我确认此贡献符合仓库许可证、贡献规范和行为准则。
- [x] I have formatted the changed code with `gofmt`, `go fmt`, or `prettier` where applicable.
      / 我已按适用情况使用 `gofmt`、`go fmt` 或 `prettier` 格式化变更代码。
- [ ] I have requested review from relevant maintainers or code owners where applicable.
      / 我已在适用情况下请求相关维护者或代码所有者审查。

## AI Disclosure / AI 使用声明

- [x] This PR includes AI-assisted content.
      / 此 PR 包含 AI 辅助内容。

Tools used / 使用工具:

- [ ] ChatGPT
- [x] Codex
- [ ] GitHub Copilot
- [ ] Claude
- [ ] Gemini
- [ ] Other (please specify) / 其他（请注明）:

Usage scope / 使用范围:

- [x] Code generation / 代码生成
- [ ] Refactoring / 重构
- [ ] Documentation / 文档
- [ ] Tests / 测试
- [ ] Translation / 翻译
- [x] Review assistance / 审查辅助

Codex reviewed the referenced reports and proposed changes, implemented the fixes, and drafted the commit and PR descriptions under human direction.

- [ ] I have reviewed and validated all AI-assisted content included in this PR.
      / 我已审核并验证此 PR 中的所有 AI 辅助内容。
- [x] I have ensured that all AI-assisted commits include `Co-Authored-By` attribution.
      / 我已确保所有 AI 辅助提交都包含 `Co-Authored-By` 归属信息。
- [ ] I can reproduce all AI-assisted content included in this PR without any AI tools.
      / 我可以在没有任何 AI 工具的情况下重现此 PR 中包含的所有 AI 辅助内容。
